### PR TITLE
chore(ci): force Node 24 for javascript actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switch release-please workflow to run JavaScript actions on Node 24 and remove deprecation warnings.