### PR TITLE
chore(ci): force Node 24 for all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     name: Test and Vet

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/internal/confluence/attachments_client.go
+++ b/internal/confluence/attachments_client.go
@@ -100,18 +100,21 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachment AttachmentDa
 	if err != nil {
 		return nil, fmt.Errorf("request attachment redirect URI: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	var downloadURL string
-	if resp.StatusCode == http.StatusMovedPermanently || resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusSeeOther || resp.StatusCode == http.StatusTemporaryRedirect || resp.StatusCode == http.StatusPermanentRedirect {
+	switch resp.StatusCode {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
 		downloadURL = resolveNextEndpoint(c.baseURL, resp.Header.Get("Location"))
 		if strings.TrimSpace(downloadURL) == "" {
 			return nil, fmt.Errorf("attachment redirect missing Location header")
 		}
-	} else if resp.StatusCode == http.StatusOK {
+	case http.StatusOK:
 		const maxBytes = 100 * 1024 * 1024
 		return io.ReadAll(io.LimitReader(resp.Body, maxBytes))
-	} else {
+	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("attachment redirect endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
@@ -125,7 +128,9 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachment AttachmentDa
 	if err != nil {
 		return nil, fmt.Errorf("download attachment file: %w", err)
 	}
-	defer fileResp.Body.Close()
+	defer func() {
+		_ = fileResp.Body.Close()
+	}()
 
 	if fileResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(fileResp.Body, 1024))

--- a/internal/confluence/client.go
+++ b/internal/confluence/client.go
@@ -211,7 +211,9 @@ func (c *Client) ResolvePageURLByTitle(ctx context.Context, title, spaceKey stri
 	if err != nil {
 		return "", fmt.Errorf("search page by title: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body := readLimitedBody(resp.Body, 1024)

--- a/internal/confluence/comments_client.go
+++ b/internal/confluence/comments_client.go
@@ -82,7 +82,7 @@ func (c *Client) fetchV2CommentsFromEndpoint(ctx context.Context, endpoint strin
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			body := readLimitedBody(resp.Body, 2048)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusNotFound {
 				return comments, nil
 			}
@@ -109,10 +109,10 @@ func (c *Client) fetchV2CommentsFromEndpoint(ctx context.Context, endpoint strin
 		}
 
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("unmarshal v2 comments response: %w", err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		for _, item := range payload.Results {
 			authorID := strings.TrimSpace(item.Version.AuthorID)
@@ -168,7 +168,9 @@ func (c *Client) getUserDisplayNames(ctx context.Context, authorIDs map[string]b
 	if err != nil {
 		return nil, fmt.Errorf("request users lookup: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody := readLimitedBody(resp.Body, 2048)


### PR DESCRIPTION
Enable FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 in CI, release, and release-please workflows.