### PR TITLE
chore(ci): use RELEASE_PLEASE_TOKEN for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,6 @@ jobs:
       - name: Run release-please
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Use RELEASE_PLEASE_TOKEN so release-created events can trigger downstream workflows.