### PR TITLE
docs: clarify release artifact formats and binary naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,11 @@ Releases are automated via GitHub Actions:
 3. Merging the release PR creates a new tag and GitHub release.
 4. GoReleaser builds and uploads `confluence2md` binaries for supported platforms.
 
+Release asset format and naming:
+
+- Linux/macOS targets: `.tar.gz` archives containing `confluence2md`
+- Windows targets: `.zip` archives containing `confluence2md.exe`
+
 ## Sensitive data
 
 Never commit a `config.yaml` containing real credentials. The file is gitignored. Use `config.example.yaml` as a reference.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,27 @@ task test         # runs all tests
 task lint         # runs golangci-lint
 ```
 
+### Release Artifacts
+
+GitHub Releases publish platform binaries as compressed archives:
+
+- Linux/macOS: `.tar.gz`
+- Windows: `.zip`
+
+Supported release targets:
+
+- `linux/amd64`
+- `linux/arm64`
+- `darwin/amd64`
+- `darwin/arm64`
+- `windows/amd64`
+- `windows/arm64`
+
+Executable name inside archives:
+
+- Linux/macOS: `confluence2md`
+- Windows: `confluence2md.exe`
+
 ### Internals Documentation
 
 The diagram below shows how the full crawl mode works at a high level. For more details on specific parts of the implementation, see the linked docs:


### PR DESCRIPTION
Document release archive formats, supported targets, and executable names.