### PR TITLE
feat: add markdown front matter and start index output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+- Deterministic YAML front matter on exported Markdown pages with stable provenance fields (`page_id`, `source_url`, `canonical_url`, `space_key`, `crawled_at`) and `is_seed`.
+- Minimal `output/index.md` generation as a human start page with crawl checkpoint summary and seed page links.
+- Metadata root `seed_page_ids` persisted from configured seeds for explicit seed semantics.
 
 ### Changed
+- Reused-page artifact materialization now writes normalized pages with front matter.
+- Export browsing guidance now points to `output/index.md` as the primary entrypoint.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # `confluence2md` - Confluence to Markdown crawler and converter
 
+[![CI](https://github.com/gkoos/confluence2md/actions/workflows/ci.yml/badge.svg)](https://github.com/gkoos/confluence2md/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/gkoos/confluence2md)](https://github.com/gkoos/confluence2md/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/gkoos/confluence2md/blob/main/LICENSE)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/gkoos/confluence2md)](https://github.com/gkoos/confluence2md/blob/main/go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gkoos/confluence2md)](https://goreportcard.com/report/github.com/gkoos/confluence2md)
+
 Turn your Confluence space into Markdown files on your hard drive and use that local copy to:
 
 - build a second brain
@@ -14,9 +20,11 @@ Turn your Confluence space into Markdown files on your hard drive and use that l
 
 What you get:
 - One local `.md` file per crawled page, with stable filenames that include page IDs.
+- Deterministic YAML front matter on each page with source/provenance fields and `is_seed`.
 - Links between crawled pages rewritten to relative local links.
 - External or out-of-scope links preserved as original URLs.
 - Page comments appended under a `## Comments` section.
+- A human-friendly `index.md` start page with crawl summary and seed links.
 - A `metadata.json` index with page metadata plus incoming/outgoing link graph data.
 
 ## What It Does
@@ -28,6 +36,7 @@ What you get:
 - Downloads page attachments and rewrites attachment references to point to the downloaded files.
 - Appends page comments under a `## Comments` section in each page file.
 - Writes a single `metadata.json` with crawl metadata and a bidirectional link graph.
+- Persists configured seed page IDs at metadata root (`seed_page_ids`) for stable seed semantics.
 - Supports two run modes:
   - **full**: crawl all pages reachable from seeds up to max depth.
   - **updates**: run the same seed-based traversal as full mode, but selectively re-process dirty pages while reusing clean-page artifacts.
@@ -102,7 +111,7 @@ confluence2md --mode full
 
 Note: full mode clears the configured output directory before crawling.
 
-Once it completes, open `output/` to inspect the generated Markdown files.
+Once it completes, start at `output/index.md` for crawl summary and seed entrypoints.
 
 ### CLI Usage
 
@@ -179,11 +188,34 @@ Because the rewrite pass only runs after crawling is complete, every decision is
 
 ```
 output/
+├── index.md                      # start-here page: crawl summary + seed links
 ├── metadata.json                  # all-pages index: metadata + link graph
-├── {title-slug}_{page-id}.md      # one file per page (comments appended at bottom)
+├── {title-slug}_{page-id}.md      # one file per page (front matter + page body + comments)
 └── attachments/
   └── {page-id}_{original-filename}
 ```
+
+### Markdown Front Matter
+
+Each exported page starts with deterministic YAML front matter:
+
+- Required fields:
+  - `page_id`
+  - `title`
+  - `source_url`
+  - `canonical_url`
+  - `space_key`
+  - `is_seed`
+  - `crawled_at`
+- Optional fields:
+  - `comment_count` (present only when greater than 0)
+  - `comments_fetch_error` (present only when non-empty)
+  - `attachments` (present only when non-empty)
+
+Seed semantics:
+
+- `is_seed` is derived from membership in metadata root `seed_page_ids`.
+- Traversal `depth` is still tracked in `metadata.json`, but not surfaced in front matter.
 
 ## Building, Testing, and Internals
 

--- a/cmd/crawler/finalize.go
+++ b/cmd/crawler/finalize.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gkoos/confluence2md/internal/crawl"
 	"github.com/gkoos/confluence2md/internal/links"
@@ -50,6 +51,78 @@ func finalizeTraversalOutput(outputDir string, w *store.Writer) (links.RewriteSt
 	}
 
 	return stats, nil
+}
+
+func writeStartIndex(outputDir string, w *store.Writer) error {
+	indexPath := filepath.Join(outputDir, "index.md")
+	pagesByID := w.GetPages()
+	seedPageIDs := w.GetSeedPageIDs()
+	lastSuccessful := w.LastSuccessfulCheckpoint()
+	lastCompleted := w.LastCompletedCheckpoint()
+
+	var b strings.Builder
+	b.WriteString("# Start Here\n\n")
+	b.WriteString("This index highlights crawl checkpoints and configured seed pages.\n\n")
+	b.WriteString("## Crawl Summary\n\n")
+	b.WriteString("- Last successful crawl: ")
+	b.WriteString(formatCheckpoint(lastSuccessful))
+	b.WriteString("\n")
+	b.WriteString("- Last completed crawl: ")
+	b.WriteString(formatCheckpoint(lastCompleted))
+	b.WriteString("\n\n")
+	b.WriteString("## Seed Pages\n\n")
+
+	if len(seedPageIDs) == 0 {
+		b.WriteString("- No configured seed pages were recorded for this crawl.\n")
+	} else {
+		for _, seedID := range seedPageIDs {
+			record, ok := pagesByID[seedID]
+			if !ok {
+				b.WriteString("- Page ")
+				b.WriteString(seedID)
+				b.WriteString(" (not present in current crawl output)\n")
+				continue
+			}
+
+			title := strings.TrimSpace(record.Title)
+			if title == "" {
+				title = "Page " + seedID
+			}
+
+			localPath := normalizeManagedPath(record.LocalPath)
+			if localPath == "" {
+				localPath = fmt.Sprintf("%s_%s.md", strings.ToLower(strings.ReplaceAll(title, " ", "-")), seedID)
+			}
+
+			b.WriteString("- [")
+			b.WriteString(title)
+			b.WriteString("](")
+			b.WriteString(localPath)
+			b.WriteString(")")
+			if sourceURL := strings.TrimSpace(record.SourceURL); sourceURL != "" {
+				b.WriteString(" - source: <")
+				b.WriteString(sourceURL)
+				b.WriteString(">")
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n## Metadata\n\n")
+	b.WriteString("- See [metadata.json](metadata.json) for full graph and diagnostic details.\n")
+
+	if err := os.WriteFile(indexPath, []byte(b.String()), 0644); err != nil {
+		return fmt.Errorf("write index.md: %w", err)
+	}
+
+	return nil
+}
+
+func formatCheckpoint(cp store.CheckpointSnapshot) string {
+	if !cp.Present {
+		return "not available"
+	}
+	return fmt.Sprintf("mode=%s, started=%s, completed=%s", cp.Mode, cp.StartedAt.UTC().Format(time.RFC3339), cp.CompletedAt.UTC().Format(time.RFC3339))
 }
 
 type artifactReconcileStats struct {

--- a/cmd/crawler/main_test.go
+++ b/cmd/crawler/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -354,5 +355,64 @@ func TestFinalizeRun_ZeroErrorsAdvanceCompletedAndSuccessful(t *testing.T) {
 	}
 	if successful.Mode != "full" {
 		t.Fatalf("expected successful checkpoint mode full, got %q", successful.Mode)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(outDir, "index.md")); statErr != nil {
+		t.Fatalf("expected index.md to be generated, stat err=%v", statErr)
+	}
+}
+
+func TestWriteStartIndex_IncludesSummaryAndSeedLinks(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	start := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Minute)
+	if err := w.MarkCompletedCheckpoint("updates", start, end); err != nil {
+		t.Fatalf("MarkCompletedCheckpoint returned error: %v", err)
+	}
+	if err := w.MarkSuccessfulCheckpoint("updates", start, end); err != nil {
+		t.Fatalf("MarkSuccessfulCheckpoint returned error: %v", err)
+	}
+
+	w.SetSeedPageIDs([]string{"100", "999"})
+	w.AddPageMetadata("100", store.PageRecord{
+		ID:           "100",
+		Title:        "Decision Records",
+		LocalPath:    "decision-records_100.md",
+		SourceURL:    "https://example/wiki/pages/viewpage.action?pageId=100",
+		CanonicalURL: "https://example/wiki/pages/viewpage.action?pageId=100",
+		SpaceKey:     "SFD",
+		CrawledAt:    start,
+	})
+
+	if err := writeStartIndex(outDir, w); err != nil {
+		t.Fatalf("writeStartIndex returned error: %v", err)
+	}
+
+	indexBytes, err := os.ReadFile(filepath.Join(outDir, "index.md"))
+	if err != nil {
+		t.Fatalf("read index.md: %v", err)
+	}
+	index := string(indexBytes)
+
+	wants := []string{
+		"# Start Here",
+		"## Crawl Summary",
+		"mode=updates, started=2026-05-23T12:00:00Z, completed=2026-05-23T12:02:00Z",
+		"## Seed Pages",
+		"- [Decision Records](decision-records_100.md) - source: <https://example/wiki/pages/viewpage.action?pageId=100>",
+		"- Page 999 (not present in current crawl output)",
+		"## Metadata",
+		"[metadata.json](metadata.json)",
+	}
+
+	for _, want := range wants {
+		if !strings.Contains(index, want) {
+			t.Fatalf("expected index to contain %q, got:\n%s", want, index)
+		}
 	}
 }

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -334,6 +334,10 @@ func finalizeRun(rc *runContext, metrics *runMetrics) (*runFinalizeResult, error
 		return nil, fmt.Errorf("save metadata: %w", err)
 	}
 
+	if err := writeStartIndex(rc.cfg.Output.Dir, rc.writer); err != nil {
+		return nil, fmt.Errorf("write start index: %w", err)
+	}
+
 	return &runFinalizeResult{
 		rewriteStats:       rewriteStats,
 		reconcileStats:     reconcileStats,

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -98,6 +98,7 @@ func bootstrapRun(mode, cfgFile string) (*runContext, error) {
 	if err != nil {
 		return nil, fmt.Errorf("extract seed page IDs: %w", err)
 	}
+	rc.writer.SetSeedPageIDs(int64SliceToStringIDs(rc.seedPageIDs))
 
 	fmt.Printf("\nStarting BFS crawl: %d seed(s), max depth %d, concurrency %d, rate %d rpm\n",
 		len(rc.seedPageIDs), cfg.Crawl.MaxDepth, cfg.Crawl.Concurrency, cfg.Crawl.RateLimitRPM)

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -155,8 +155,9 @@ func processReusedPage(rc *runContext, metrics *runMetrics, pageID int64, crawle
 		logPageWithLevel("ERR", pageID, "reused page missing from previous metadata")
 		return fmt.Errorf("reused page missing from previous metadata")
 	}
+	materializedMarkdown := store.ComposeMarkdownWithFrontMatter(pageIDStr, previous, rc.writer.GetSeedPageIDs(), crawledPage.Markdown)
 
-	materialized, materializeErr := ensureLocalPageArtifact(rc.cfg.Output.Dir, previous, crawledPage.Markdown)
+	materialized, materializeErr := ensureLocalPageArtifact(rc.cfg.Output.Dir, previous, materializedMarkdown)
 	if materializeErr != nil {
 		logPageWithLevel("ERR", pageID, "reused page artifact check failed: %v", materializeErr)
 		return materializeErr

--- a/internal/store/frontmatter.go
+++ b/internal/store/frontmatter.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ComposeMarkdownWithFrontMatter returns markdown with a deterministic YAML front matter preamble.
+func ComposeMarkdownWithFrontMatter(pageID string, pageRecord PageRecord, seedPageIDs []string, markdown string) string {
+	body := stripExistingFrontMatter(markdown)
+	frontMatter := renderFrontMatter(pageID, pageRecord, seedPageIDs)
+	body = strings.TrimLeft(body, "\n")
+	if body == "" {
+		return frontMatter + "\n"
+	}
+	return frontMatter + "\n" + body
+}
+
+func renderFrontMatter(pageID string, pageRecord PageRecord, seedPageIDs []string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("page_id: ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(pageID)))
+	b.WriteString("\n")
+	b.WriteString("title: ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(pageRecord.Title)))
+	b.WriteString("\n")
+	b.WriteString("source_url: ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(pageRecord.SourceURL)))
+	b.WriteString("\n")
+	b.WriteString("canonical_url: ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(pageRecord.CanonicalURL)))
+	b.WriteString("\n")
+	b.WriteString("space_key: ")
+	b.WriteString(strconv.Quote(strings.TrimSpace(pageRecord.SpaceKey)))
+	b.WriteString("\n")
+	b.WriteString("is_seed: ")
+	b.WriteString(strconv.FormatBool(isSeedPage(pageID, seedPageIDs)))
+	b.WriteString("\n")
+	b.WriteString("crawled_at: ")
+	b.WriteString(strconv.Quote(pageRecord.CrawledAt.UTC().Format("2006-01-02T15:04:05Z")))
+	b.WriteString("\n")
+
+	if pageRecord.CommentCount > 0 {
+		b.WriteString("comment_count: ")
+		b.WriteString(strconv.Itoa(pageRecord.CommentCount))
+		b.WriteString("\n")
+	}
+
+	if errMsg := strings.TrimSpace(pageRecord.CommentsFetchError); errMsg != "" {
+		b.WriteString("comments_fetch_error: ")
+		b.WriteString(strconv.Quote(strings.ReplaceAll(errMsg, "\n", " ")))
+		b.WriteString("\n")
+	}
+
+	if len(pageRecord.Attachments) > 0 {
+		attachments := make([]string, 0, len(pageRecord.Attachments))
+		for _, attachment := range pageRecord.Attachments {
+			attachment = strings.TrimSpace(attachment)
+			if attachment != "" {
+				attachments = append(attachments, attachment)
+			}
+		}
+		if len(attachments) > 0 {
+			sort.Strings(attachments)
+			b.WriteString("attachments:\n")
+			for _, attachment := range attachments {
+				b.WriteString("  - ")
+				b.WriteString(strconv.Quote(attachment))
+				b.WriteString("\n")
+			}
+		}
+	}
+
+	b.WriteString("---\n")
+	return b.String()
+}
+
+func isSeedPage(pageID string, seedPageIDs []string) bool {
+	pageID = strings.TrimSpace(pageID)
+	if pageID == "" {
+		return false
+	}
+	for _, seedID := range seedPageIDs {
+		if pageID == strings.TrimSpace(seedID) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripExistingFrontMatter(markdown string) string {
+	trimmed := strings.TrimPrefix(markdown, "\ufeff")
+	if !strings.HasPrefix(trimmed, "---\n") {
+		return markdown
+	}
+
+	end := strings.Index(trimmed[4:], "\n---\n")
+	if end < 0 {
+		return markdown
+	}
+	end += 4
+	header := trimmed[:end+5]
+	if !strings.Contains(header, "page_id:") || !strings.Contains(header, "crawled_at:") {
+		return markdown
+	}
+
+	body := trimmed[end+5:]
+	body = strings.TrimLeft(body, "\n")
+	return body
+}

--- a/internal/store/frontmatter_test.go
+++ b/internal/store/frontmatter_test.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestComposeMarkdownWithFrontMatter_RequiredFieldsAndSeedFlag(t *testing.T) {
+	record := PageRecord{
+		ID:           "123",
+		Title:        "Decision Records",
+		SourceURL:    "https://example/wiki/pages/viewpage.action?pageId=123",
+		CanonicalURL: "https://example/wiki/pages/viewpage.action?pageId=123",
+		SpaceKey:     "SFD",
+		CrawledAt:    time.Date(2026, 5, 23, 12, 30, 0, 0, time.FixedZone("BST", 3600)),
+		StorageFormat: "# Decision Records\n\nBody",
+	}
+
+	out := ComposeMarkdownWithFrontMatter("123", record, []string{"123", "999"}, record.StorageFormat)
+
+	wants := []string{
+		"---\n",
+		"page_id: \"123\"\n",
+		"title: \"Decision Records\"\n",
+		"source_url: \"https://example/wiki/pages/viewpage.action?pageId=123\"\n",
+		"canonical_url: \"https://example/wiki/pages/viewpage.action?pageId=123\"\n",
+		"space_key: \"SFD\"\n",
+		"is_seed: true\n",
+		"crawled_at: \"2026-05-23T11:30:00Z\"\n",
+		"---\n\n# Decision Records\n\nBody",
+	}
+
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestComposeMarkdownWithFrontMatter_OmitsOptionalFieldsWhenEmpty(t *testing.T) {
+	record := PageRecord{
+		ID:            "321",
+		Title:         "Empty Optional",
+		SourceURL:     "https://example/wiki/pages/viewpage.action?pageId=321",
+		CanonicalURL:  "https://example/wiki/pages/viewpage.action?pageId=321",
+		SpaceKey:      "SFD",
+		CrawledAt:     time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC),
+		CommentCount:  0,
+		Attachments:   nil,
+		StorageFormat: "# Empty Optional",
+	}
+
+	out := ComposeMarkdownWithFrontMatter("321", record, []string{"123"}, record.StorageFormat)
+
+	mustNotContain := []string{
+		"comment_count:",
+		"comments_fetch_error:",
+		"attachments:",
+	}
+
+	for _, notExpected := range mustNotContain {
+		if strings.Contains(out, notExpected) {
+			t.Fatalf("did not expect output to contain %q, got:\n%s", notExpected, out)
+		}
+	}
+
+	if !strings.Contains(out, "is_seed: false\n") {
+		t.Fatalf("expected is_seed false in output, got:\n%s", out)
+	}
+}
+
+func TestComposeMarkdownWithFrontMatter_ReplacesExistingManagedFrontMatter(t *testing.T) {
+	record := PageRecord{
+		ID:            "777",
+		Title:         "Replacement",
+		SourceURL:     "https://example/wiki/pages/viewpage.action?pageId=777",
+		CanonicalURL:  "https://example/wiki/pages/viewpage.action?pageId=777",
+		SpaceKey:      "SFD",
+		CrawledAt:     time.Date(2026, 5, 23, 13, 0, 0, 0, time.UTC),
+		CommentCount:  2,
+		Attachments:   []string{"b.png", "a.png"},
+		StorageFormat: "# Replacement",
+	}
+
+	in := "---\npage_id: \"old\"\ncrawled_at: \"2020-01-01T00:00:00Z\"\n---\n# Replacement"
+	out := ComposeMarkdownWithFrontMatter("777", record, []string{"777"}, in)
+
+	if strings.Contains(out, "page_id: \"old\"") {
+		t.Fatalf("expected old front matter to be replaced, got:\n%s", out)
+	}
+	if strings.Count(out, "---\n") != 2 {
+		t.Fatalf("expected a single front matter block, got:\n%s", out)
+	}
+	if !strings.Contains(out, "attachments:\n  - \"a.png\"\n  - \"b.png\"\n") {
+		t.Fatalf("expected sorted attachments in front matter, got:\n%s", out)
+	}
+}

--- a/internal/store/fs.go
+++ b/internal/store/fs.go
@@ -181,9 +181,10 @@ func (w *Writer) WritePage(pageID, title, sourceURL, storageContent string) (str
 func (w *Writer) AddPage(pageID string, pageRecord PageRecord) error {
 	filename := generateFilename(pageRecord.Title, pageID)
 	filepath := filepath.Join(w.outputDir, filename)
+	rendered := ComposeMarkdownWithFrontMatter(pageID, pageRecord, w.metadata.SeedPageIDs, pageRecord.StorageFormat)
 
 	// Write markdown content to disk
-	if err := os.WriteFile(filepath, []byte(pageRecord.StorageFormat), 0644); err != nil {
+	if err := os.WriteFile(filepath, []byte(rendered), 0644); err != nil {
 		return fmt.Errorf("write page file %s: %w", filename, err)
 	}
 

--- a/internal/store/fs.go
+++ b/internal/store/fs.go
@@ -42,6 +42,7 @@ type Metadata struct {
 	LastSuccessfulCrawlStartedAt   time.Time             `json:"last_successful_crawl_started_at,omitempty"`
 	LastSuccessfulCrawlCompletedAt time.Time             `json:"last_successful_crawl_completed_at,omitempty"`
 	LastSuccessfulCrawlMode        string                `json:"last_successful_crawl_mode,omitempty"`
+	SeedPageIDs                    []string              `json:"seed_page_ids,omitempty"`
 	Pages                          map[string]PageRecord `json:"pages"`
 }
 
@@ -207,6 +208,18 @@ func (w *Writer) GetPages() map[string]PageRecord {
 	return w.metadata.Pages
 }
 
+// SetSeedPageIDs records canonical seed page IDs at metadata root.
+func (w *Writer) SetSeedPageIDs(seedPageIDs []string) {
+	w.metadata.SeedPageIDs = normalizeSeedPageIDs(seedPageIDs)
+}
+
+// GetSeedPageIDs returns a copy of canonical seed page IDs from metadata root.
+func (w *Writer) GetSeedPageIDs() []string {
+	out := make([]string, len(w.metadata.SeedPageIDs))
+	copy(out, w.metadata.SeedPageIDs)
+	return out
+}
+
 // SaveMetadata writes the metadata.json file to disk.
 func (w *Writer) SaveMetadata() error {
 	metaPath := filepath.Join(w.outputDir, "metadata.json")
@@ -260,6 +273,12 @@ func validateMetadata(m *Metadata) error {
 		return fmt.Errorf("pages map is missing")
 	}
 
+	for i, seedID := range m.SeedPageIDs {
+		if strings.TrimSpace(seedID) == "" {
+			return fmt.Errorf("seed_page_ids[%d] is empty", i)
+		}
+	}
+
 	for id, page := range m.Pages {
 		if id == "" {
 			return fmt.Errorf("found page with empty map key")
@@ -291,6 +310,29 @@ func validateMetadata(m *Metadata) error {
 	}
 
 	return nil
+}
+
+func normalizeSeedPageIDs(seedPageIDs []string) []string {
+	if len(seedPageIDs) == 0 {
+		return nil
+	}
+
+	normalized := make([]string, 0, len(seedPageIDs))
+	seen := make(map[string]bool, len(seedPageIDs))
+	for _, id := range seedPageIDs {
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		normalized = append(normalized, id)
+	}
+
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	return normalized
 }
 
 func validateCheckpointWriteInput(mode string, startedAt, completedAt time.Time) error {

--- a/internal/store/fs_test.go
+++ b/internal/store/fs_test.go
@@ -407,3 +407,58 @@ func TestNewWriter_LoadLegacyMetadataWithoutCompletedCheckpoint(t *testing.T) {
 		t.Fatalf("expected successful checkpoint to remain present for legacy metadata")
 	}
 }
+
+func TestSetSeedPageIDs_NormalizesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewWriter(dir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	w.SetSeedPageIDs([]string{" 123 ", "", "123", "456", " 456 ", "789"})
+
+	got := w.GetSeedPageIDs()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 normalized seed IDs, got %d: %#v", len(got), got)
+	}
+	if got[0] != "123" || got[1] != "456" || got[2] != "789" {
+		t.Fatalf("unexpected normalized seed IDs: %#v", got)
+	}
+
+	if err := w.SaveMetadata(); err != nil {
+		t.Fatalf("SaveMetadata returned error: %v", err)
+	}
+
+	w2, err := NewWriter(dir)
+	if err != nil {
+		t.Fatalf("NewWriter reload returned error: %v", err)
+	}
+
+	reloaded := w2.GetSeedPageIDs()
+	if len(reloaded) != 3 {
+		t.Fatalf("expected 3 reloaded seed IDs, got %d: %#v", len(reloaded), reloaded)
+	}
+	if reloaded[0] != "123" || reloaded[1] != "456" || reloaded[2] != "789" {
+		t.Fatalf("unexpected reloaded seed IDs: %#v", reloaded)
+	}
+}
+
+func TestNewWriter_LoadMetadataRejectsEmptySeedPageID(t *testing.T) {
+	dir := t.TempDir()
+	invalidMeta := `{
+  "crawl_started_at": "2026-01-01T00:00:00Z",
+  "seed_page_ids": ["123", ""],
+  "pages": {}
+}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(invalidMeta), 0644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+
+	_, err := NewWriter(dir)
+	if err == nil {
+		t.Fatalf("expected NewWriter to fail for empty seed page id")
+	}
+	if !strings.Contains(err.Error(), "seed_page_ids[1] is empty") {
+		t.Fatalf("expected seed_page_ids validation error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR improves exported output usability for both humans and downstream tooling:

- Persist `seed_page_ids` at metadata root
- Add deterministic YAML front matter to exported markdown pages
- Generate a minimal `output/index.md` with crawl summary and seed links
- Update README and changelog docs

## Changes
- metadata:
  - `seed_page_ids` persisted and validated
- export:
  - front matter composed for written pages
  - reused page materialization also writes front matter
- finalize:
  - write `index.md` after metadata save
- docs:
  - README updated with start-here/index + front matter schema
  - changelog unreleased entries added
- tests:
  - store tests for seed metadata + front matter rendering
  - crawler tests for index generation/finalize integration

## Validation
- `go test ./...` passes
- manual full crawl confirms:
  - front matter present on page files
  - `output/index.md` generated
  - `metadata.json` includes `seed_page_ids`