### PR TITLE
feat: document Confluence Cloud-only support, drop Data Center from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Pre-built binaries are available on the [Releases](https://github.com/gkoos/conf
 
 ### Requirements
 
+- **Confluence Cloud only.** This tool uses the Atlassian Document Format (ADF) API, which is exclusive to Confluence Cloud. Confluence Data Center and Server are not supported.
 - A valid Atlassian API token with read access to the target spaces
 
 You can generate an Atlassian API token from your Atlassian account security page:


### PR DESCRIPTION
The ADF pivot (0.6.0) made Data Center support impossible — ADF is Cloud-only. This documents that in the README and closes #18.

Also triggers release-please to create the 0.6.0 release PR.