### PR TITLE
feat: add follow_children config flag to crawl child pages via Confluence page tree

### DIFF
--- a/cmd/crawler/setup.go
+++ b/cmd/crawler/setup.go
@@ -19,9 +19,10 @@ func printConfigSummary(cfg *config.Config) {
 	fmt.Printf("  Base URL:    %s\n", cfg.BaseURL())
 	fmt.Printf("  Username:    %s\n", cfg.Confluence.Username)
 	fmt.Printf("  Seeds:       %v\n", cfg.Crawl.Seeds)
-	fmt.Printf("  Max depth:   %d\n", cfg.Crawl.MaxDepth)
-	fmt.Printf("  Concurrency: %d\n", cfg.Crawl.Concurrency)
-	fmt.Printf("  Output dir:  %s\n", cfg.Output.Dir)
+	fmt.Printf("  Max depth:      %d\n", cfg.Crawl.MaxDepth)
+	fmt.Printf("  Concurrency:    %d\n", cfg.Crawl.Concurrency)
+	fmt.Printf("  Follow children: %v\n", cfg.Crawl.FollowChildren)
+	fmt.Printf("  Output dir:     %s\n", cfg.Output.Dir)
 }
 
 func clearDirectoryContents(dir string) error {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,6 +17,10 @@ crawl:
   rate_limit_rpm: 250
   # Maximum buffered discovered pages waiting to be processed
   queue_size: 10000
+  # Also crawl child pages in the Confluence page tree hierarchy, not just
+  # pages linked from the page body. Useful when pages exist only as sidebar
+  # children with no inline links or macros. Shares max_depth with link traversal.
+  follow_children: false
 
 output:
   # Directory to write Markdown files, attachments, and metadata

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,11 +23,12 @@ type ConfluenceConfig struct {
 }
 
 type CrawlConfig struct {
-	Seeds        []string `mapstructure:"seeds"`
-	MaxDepth     int      `mapstructure:"max_depth"`
-	Concurrency  int      `mapstructure:"concurrency"`
-	RateLimitRPM int      `mapstructure:"rate_limit_rpm"`
-	QueueSize    int      `mapstructure:"queue_size"`
+	Seeds          []string `mapstructure:"seeds"`
+	MaxDepth        int      `mapstructure:"max_depth"`
+	Concurrency     int      `mapstructure:"concurrency"`
+	RateLimitRPM    int      `mapstructure:"rate_limit_rpm"`
+	QueueSize       int      `mapstructure:"queue_size"`
+	FollowChildren  bool     `mapstructure:"follow_children"`
 }
 
 type OutputConfig struct {

--- a/internal/crawl/full.go
+++ b/internal/crawl/full.go
@@ -346,9 +346,10 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 		page.OutgoingLinks = links.DedupPageIDs(append(page.OutgoingLinks, commentIDs...))
 	}
 
-	// If the page contains a "children" macro, the child pages are not represented
-	// as inline links in ADF — fetch them via the API and add to outgoing links.
-	if links.HasChildrenMacro(fetchedPage.Body.ADF.Value) {
+	// If the page contains a "children" macro, or follow_children is enabled,
+	// child pages are not represented as inline links in ADF — fetch them via
+	// the API and add to outgoing links.
+	if links.HasChildrenMacro(fetchedPage.Body.ADF.Value) || cs.config.Crawl.FollowChildren {
 		childIDs, err := cs.client.GetPageChildIDs(ctx, pageID)
 		if err != nil {
 			// Non-fatal: log but continue with whatever inline links we already have.


### PR DESCRIPTION
Adds \crawl.follow_children: false\ config option. When true, calls the Confluence children API on every crawled page, discovering pages that exist only in the sidebar tree with no inline links or macros in the body. Shares \max_depth\ with link-based traversal.

closes #36