### PR TITLE
feat: add accurate dry-run mode for full and updates crawls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ What you get:
 - Supports two run modes:
   - **full**: crawl all pages reachable from seeds up to max depth.
   - **updates**: run the same seed-based traversal as full mode, but selectively re-process dirty pages while reusing clean-page artifacts.
+- Supports a **dry-run** modifier (`--dry-run`) for both modes to preview traversal and updates decisions without writing output artifacts.
 
 ## Download
 
@@ -115,6 +116,12 @@ confluence2md --mode full
 
 Note: full mode clears the configured output directory before crawling.
 
+To preview impact without writing files:
+
+```sh
+confluence2md --mode full --dry-run
+```
+
 Once it completes, start at `output/index.md` for crawl summary and seed entrypoints.
 
 ### CLI Usage
@@ -125,6 +132,12 @@ confluence2md --mode full
 
 # Incremental update (same seed traversal, selective page re-processing)
 confluence2md --mode updates
+
+# Full dry-run (no writes: pages/attachments/metadata/index/checkpoints)
+confluence2md --mode full --dry-run
+
+# Updates dry-run (same traversal + dirty/clean decisions, no writes)
+confluence2md --mode updates --dry-run
 
 # Validate config and Confluence API credentials without crawling
 confluence2md validate
@@ -166,6 +179,13 @@ For updates mode, the summary additionally reports:
 - Attachments downloaded/reused
 - Output commit status
 - Checkpoint advanced status (successful-checkpoint advancement)
+
+For dry-run mode, the summary indicates:
+
+- Dry-run mode is active (no writes)
+- Link rewrite pass is skipped
+- File/attachment/deletion counts are reported as "would" or predicted outcomes
+- Checkpoint advancement is suppressed
 
 Note: current output commit behavior is direct-write (non-transactional).
 

--- a/cmd/crawler/finalize.go
+++ b/cmd/crawler/finalize.go
@@ -166,6 +166,21 @@ func reconcileManagedArtifacts(outputDir string, oldPages, newPages map[string]s
 	return stats, nil
 }
 
+func previewManagedArtifactReconcile(oldPages, newPages map[string]store.PageRecord) artifactReconcileStats {
+	stats := artifactReconcileStats{}
+	oldSet := managedArtifactSet(oldPages)
+	newSet := managedArtifactSet(newPages)
+
+	for relPath := range oldSet {
+		if _, keep := newSet[relPath]; keep {
+			continue
+		}
+		stats.Deleted++
+	}
+
+	return stats
+}
+
 func managedArtifactSet(pages map[string]store.PageRecord) map[string]struct{} {
 	artifacts := make(map[string]struct{})
 	for _, record := range pages {

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -13,6 +13,7 @@ import (
 var (
 	cfgFile   string
 	mode      string
+	dryRun    bool
 	startTime time.Time
 )
 
@@ -31,11 +32,12 @@ var validateCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVar(&cfgFile, "config", "config.yaml", "Path to config file")
 	rootCmd.Flags().StringVar(&mode, "mode", "", "Crawl mode: full or updates (required)")
+	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview crawl scope and decisions without writing output artifacts")
 	rootCmd.AddCommand(validateCmd)
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	rc, err := bootstrapRun(mode, cfgFile)
+	rc, err := bootstrapRun(mode, cfgFile, dryRun)
 	if err != nil {
 		return err
 	}

--- a/cmd/crawler/main_test.go
+++ b/cmd/crawler/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gkoos/confluence2md/internal/config"
+	"github.com/gkoos/confluence2md/internal/confluence"
 	"github.com/gkoos/confluence2md/internal/crawl"
 	"github.com/gkoos/confluence2md/internal/store"
 )
@@ -362,6 +364,67 @@ func TestFinalizeRun_ZeroErrorsAdvanceCompletedAndSuccessful(t *testing.T) {
 	}
 }
 
+func TestFinalizeRun_DryRunSkipsWritesAndCheckpoints(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	oldStart := time.Now().UTC().Add(-2 * time.Hour)
+	oldEnd := oldStart.Add(1 * time.Minute)
+	if err := w.MarkSuccessfulCheckpoint("full", oldStart, oldEnd); err != nil {
+		t.Fatalf("MarkSuccessfulCheckpoint returned error: %v", err)
+	}
+
+	rc := &runContext{
+		mode:               "updates",
+		dryRun:             true,
+		cfg:                &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:             w,
+		crawlResults:       map[int64]*crawl.CrawledPage{},
+		previousCheckpoint: w.LastSuccessfulCheckpoint(),
+		previousPages: map[string]store.PageRecord{
+			"123": {ID: "123", LocalPath: "page_123.md"},
+		},
+	}
+	metrics := &runMetrics{errorCount: 0}
+
+	result, err := finalizeRun(rc, metrics)
+	if err != nil {
+		t.Fatalf("finalizeRun returned error: %v", err)
+	}
+	if result.checkpointAdvanced {
+		t.Fatalf("expected dry-run not to advance successful checkpoint")
+	}
+	if result.reconcileStats.Deleted != 1 {
+		t.Fatalf("expected dry-run to preview 1 stale artifact delete, got %d", result.reconcileStats.Deleted)
+	}
+
+	completed := w.LastCompletedCheckpoint()
+	if completed.Present {
+		t.Fatalf("expected dry-run not to write completed checkpoint")
+	}
+
+	successful := w.LastSuccessfulCheckpoint()
+	if !successful.Present {
+		t.Fatalf("expected successful checkpoint to remain present")
+	}
+	if successful.Mode != "full" {
+		t.Fatalf("expected successful checkpoint mode to remain full, got %q", successful.Mode)
+	}
+	if !successful.StartedAt.Equal(oldStart) || !successful.CompletedAt.Equal(oldEnd) {
+		t.Fatalf("expected successful checkpoint tuple unchanged")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(outDir, "index.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dry-run not to generate index.md, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(outDir, "metadata.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dry-run not to save metadata.json, stat err=%v", statErr)
+	}
+}
+
 func TestWriteStartIndex_IncludesSummaryAndSeedLinks(t *testing.T) {
 	outDir := t.TempDir()
 	w, err := store.NewWriter(outDir)
@@ -414,5 +477,143 @@ func TestWriteStartIndex_IncludesSummaryAndSeedLinks(t *testing.T) {
 		if !strings.Contains(index, want) {
 			t.Fatalf("expected index to contain %q, got:\n%s", want, index)
 		}
+	}
+}
+
+func TestRootCommand_HasDryRunFlagWithDefaultFalse(t *testing.T) {
+	flag := rootCmd.Flags().Lookup("dry-run")
+	if flag == nil {
+		t.Fatalf("expected dry-run flag to be registered")
+	}
+
+	if flag.DefValue != "false" {
+		t.Fatalf("expected dry-run default to be false, got %q", flag.DefValue)
+	}
+}
+
+func TestProcessReusedPage_DryRunSkipsArtifactMaterialization(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	w.SetSeedPageIDs([]string{"123"})
+
+	previous := store.PageRecord{
+		ID:            "123",
+		Title:         "Decision Records",
+		LocalPath:     "decision-records_123.md",
+		OutgoingLinks: []string{"555"},
+	}
+	previousPages := map[string]store.PageRecord{"123": previous}
+
+	rc := &runContext{
+		dryRun:              true,
+		cfg:                 &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:              w,
+		previousPages:       previousPages,
+		oldManagedArtifacts: managedArtifactSet(previousPages),
+	}
+	metrics := &runMetrics{}
+	crawledPage := &crawl.CrawledPage{
+		ID:           123,
+		Title:        "Decision Records",
+		Depth:        1,
+		OutgoingLinks: []int64{555},
+	}
+
+	if err := processReusedPage(rc, metrics, 123, crawledPage); err != nil {
+		t.Fatalf("processReusedPage returned error: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(outDir, previous.LocalPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dry-run to skip reused-page artifact write, stat err=%v", statErr)
+	}
+	if got := metrics.fileAddedCount; got != 1 {
+		t.Fatalf("expected dry-run to predict one added reused artifact, got %d", got)
+	}
+	if got := metrics.reusedCount; got != 1 {
+		t.Fatalf("expected reused count 1, got %d", got)
+	}
+	if got := metrics.successCount; got != 1 {
+		t.Fatalf("expected success count 1, got %d", got)
+	}
+}
+
+func TestProcessRerenderedPage_DryRunSkipsPageAndAttachmentWrites(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+
+	rc := &runContext{
+		dryRun: true,
+		cfg: &config.Config{
+			Confluence: config.ConfluenceConfig{Username: "user", Token: "token"},
+			Crawl:      config.CrawlConfig{Seeds: []string{"https://example.atlassian.net/wiki/spaces/SPACE/pages/123/Title"}},
+			Output:     config.OutputConfig{Dir: outDir},
+			Attachments: config.AttachmentsConfig{
+				Download:  true,
+				MaxSizeMB: 10,
+			},
+			Retry: config.RetryConfig{MaxAttempts: 1, InitialBackoffMS: 1000},
+		},
+		writer:              w,
+		oldManagedArtifacts: map[string]struct{}{},
+	}
+	metrics := &runMetrics{}
+	crawledPage := &crawl.CrawledPage{
+		ID:               123,
+		Title:            "Rendering Candidate",
+		Version:          2,
+		SourceURL:        "https://example.atlassian.net/wiki/pages/viewpage.action?pageId=123",
+		CanonicalURL:     "https://example.atlassian.net/wiki/pages/viewpage.action?pageId=123",
+		SpaceKey:         "SPACE",
+		Depth:            0,
+		CrawledAt:        time.Now().UTC(),
+		OutgoingLinks:    []int64{456},
+		CommentCount:     1,
+		Comments:         []confluence.CommentData{{ID: "c1", Body: "{\"type\":\"doc\",\"content\":[]}"}},
+		Attachments:      []confluence.AttachmentData{{ID: "a1", Filename: "diagram.png", FileID: "fid-1", FileSizeBytes: 1024}},
+		CreatedByID:      "u1",
+		LastModifiedByID: "u2",
+	}
+
+	if err := processRerenderedPage(context.Background(), rc, metrics, 123, crawledPage); err != nil {
+		t.Fatalf("processRerenderedPage returned error: %v", err)
+	}
+
+	entries, readErr := os.ReadDir(outDir)
+	if readErr != nil {
+		t.Fatalf("ReadDir returned error: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected dry-run to avoid filesystem writes, found %d entries", len(entries))
+	}
+
+	if got := metrics.successCount; got != 1 {
+		t.Fatalf("expected success count 1, got %d", got)
+	}
+	if got := metrics.rerenderedCount; got != 1 {
+		t.Fatalf("expected rerendered count 1, got %d", got)
+	}
+	if got := metrics.attachmentsDownloaded; got != 1 {
+		t.Fatalf("expected one predicted attachment download, got %d", got)
+	}
+	if got := metrics.fileAddedCount; got != 2 {
+		t.Fatalf("expected predicted added files count 2 (page + attachment), got %d", got)
+	}
+}
+
+func TestShouldPrepareOutputDirectory(t *testing.T) {
+	if !shouldPrepareOutputDirectory("full", false) {
+		t.Fatalf("expected full non-dry-run to prepare output directory")
+	}
+	if shouldPrepareOutputDirectory("full", true) {
+		t.Fatalf("expected full dry-run not to prepare output directory")
+	}
+	if shouldPrepareOutputDirectory("updates", false) {
+		t.Fatalf("expected updates mode not to prepare output directory")
 	}
 }

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -19,6 +19,7 @@ import (
 
 type runContext struct {
 	mode                string
+	dryRun              bool
 	cfg                 *config.Config
 	client              *confluenceclient.Client
 	writer              *store.Writer
@@ -51,7 +52,7 @@ type runFinalizeResult struct {
 	checkpointAdvanced bool
 }
 
-func bootstrapRun(mode, cfgFile string) (*runContext, error) {
+func bootstrapRun(mode, cfgFile string, dryRun bool) (*runContext, error) {
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
 		return nil, fmt.Errorf("config error: %w", err)
@@ -72,7 +73,7 @@ func bootstrapRun(mode, cfgFile string) (*runContext, error) {
 		return nil, err
 	}
 
-	if mode == "full" {
+	if shouldPrepareOutputDirectory(mode, dryRun) {
 		if err := clearDirectoryContents(cfg.Output.Dir); err != nil {
 			return nil, fmt.Errorf("prepare output directory for full crawl: %w", err)
 		}
@@ -86,6 +87,7 @@ func bootstrapRun(mode, cfgFile string) (*runContext, error) {
 	previousPages := snapshotPageRecords(writer.GetPages())
 	rc := &runContext{
 		mode:                mode,
+		dryRun:              dryRun,
 		cfg:                 cfg,
 		client:              client,
 		writer:              writer,
@@ -112,11 +114,16 @@ func bootstrapRun(mode, cfgFile string) (*runContext, error) {
 	}
 
 	rc.crawler = crawl.NewCrawlSession(client, cfg, rc.spaceKey)
+	rc.crawler.SetDryRun(dryRun)
 	if rc.mode == "updates" {
 		rc.crawler.EnableUpdatesMode(rc.previousPages)
 	}
 
 	return rc, nil
+}
+
+func shouldPrepareOutputDirectory(mode string, dryRun bool) bool {
+	return mode == "full" && !dryRun
 }
 
 func executeTraversal(ctx context.Context, rc *runContext) error {
@@ -126,7 +133,11 @@ func executeTraversal(ctx context.Context, rc *runContext) error {
 	}
 	rc.crawlResults = crawlResults
 
-	fmt.Printf("\nProcessing and writing %d crawled pages...\n", len(crawlResults))
+	if rc.dryRun {
+		fmt.Printf("\nProcessing %d crawled pages (dry-run, no writes)...\n", len(crawlResults))
+	} else {
+		fmt.Printf("\nProcessing and writing %d crawled pages...\n", len(crawlResults))
+	}
 	return nil
 }
 
@@ -155,15 +166,20 @@ func processReusedPage(rc *runContext, metrics *runMetrics, pageID int64, crawle
 		logPageWithLevel("ERR", pageID, "reused page missing from previous metadata")
 		return fmt.Errorf("reused page missing from previous metadata")
 	}
-	materializedMarkdown := store.ComposeMarkdownWithFrontMatter(pageIDStr, previous, rc.writer.GetSeedPageIDs(), crawledPage.Markdown)
-
-	materialized, materializeErr := ensureLocalPageArtifact(rc.cfg.Output.Dir, previous, materializedMarkdown)
-	if materializeErr != nil {
-		logPageWithLevel("ERR", pageID, "reused page artifact check failed: %v", materializeErr)
-		return materializeErr
-	}
-	if materialized {
-		metrics.fileAddedCount++
+	if rc.dryRun {
+		if reusedPageArtifactMissing(rc.cfg.Output.Dir, previous) {
+			metrics.fileAddedCount++
+		}
+	} else {
+		materializedMarkdown := store.ComposeMarkdownWithFrontMatter(pageIDStr, previous, rc.writer.GetSeedPageIDs(), crawledPage.Markdown)
+		materialized, materializeErr := ensureLocalPageArtifact(rc.cfg.Output.Dir, previous, materializedMarkdown)
+		if materializeErr != nil {
+			logPageWithLevel("ERR", pageID, "reused page artifact check failed: %v", materializeErr)
+			return materializeErr
+		}
+		if materialized {
+			metrics.fileAddedCount++
+		}
 	}
 
 	record := previous
@@ -175,7 +191,11 @@ func processReusedPage(rc *runContext, metrics *runMetrics, pageID int64, crawle
 	}
 
 	rc.writer.AddPageMetadata(pageIDStr, record)
-	logPageWithLevel("OK", pageID, "%s (reused)", record.Title)
+	if rc.dryRun {
+		logPageWithLevel("OK", pageID, "%s (reused, dry-run)", record.Title)
+	} else {
+		logPageWithLevel("OK", pageID, "%s (reused)", record.Title)
+	}
 	metrics.successCount++
 	metrics.reusedCount++
 	for _, filename := range record.Attachments {
@@ -200,16 +220,18 @@ func processRerenderedPage(ctx context.Context, rc *runContext, metrics *runMetr
 	pageIDStr := strconv.FormatInt(pageID, 10)
 	markdown := crawledPage.Markdown
 
-	var err error
-	markdown, err = absolutizeConfluenceLinks(markdown, rc.cfg.BaseURL())
-	if err != nil {
-		logPageWithLevel("ERR", pageID, "absolutize links failed: %v", err)
-		return err
-	}
+	if !rc.dryRun {
+		var err error
+		markdown, err = absolutizeConfluenceLinks(markdown, rc.cfg.BaseURL())
+		if err != nil {
+			logPageWithLevel("ERR", pageID, "absolutize links failed: %v", err)
+			return err
+		}
 
-	markdown, err = enrichURLOnlyLinkLabels(markdown, rc.client)
-	if err != nil {
-		logPageWithLevel("WARN", pageID, "enrich links failed: %v", err)
+		markdown, err = enrichURLOnlyLinkLabels(markdown, rc.client)
+		if err != nil {
+			logPageWithLevel("WARN", pageID, "enrich links failed: %v", err)
+		}
 	}
 
 	if crawledPage.CommentFetchError != "" {
@@ -222,7 +244,12 @@ func processRerenderedPage(ctx context.Context, rc *runContext, metrics *runMetr
 		if crawledPage.AttachmentFetchError != "" {
 			logPageWithLevel("WARN", pageID, "%s", crawledPage.AttachmentFetchError)
 		}
-		results := store.DownloadPageAttachments(ctx, rc.cfg.Output.Dir, pageIDStr, crawledPage.Attachments, rc.cfg.Attachments.MaxSizeMB, rc.client)
+		var results []store.AttachmentResult
+		if rc.dryRun {
+			results = previewPageAttachments(pageIDStr, crawledPage.Attachments, rc.cfg.Attachments.MaxSizeMB)
+		} else {
+			results = store.DownloadPageAttachments(ctx, rc.cfg.Output.Dir, pageIDStr, crawledPage.Attachments, rc.cfg.Attachments.MaxSizeMB, rc.client)
+		}
 		for _, r := range results {
 			if r.Error != nil {
 				logPageAttachmentWarning(pageID, r.Error)
@@ -237,14 +264,21 @@ func processRerenderedPage(ctx context.Context, rc *runContext, metrics *runMetr
 				}
 			}
 		}
-		markdown = rewriteAttachmentLinks(markdown, results)
+		if !rc.dryRun {
+			markdown = rewriteAttachmentLinks(markdown, results)
+		}
 	}
 
-	commentsMD := convert.CommentsToMarkdown(crawledPage.Comments)
-	if commentsMD != "" {
-		markdown = strings.TrimRight(markdown, "\n") + "\n\n" + commentsMD + "\n"
+	if crawledPage.CommentCount > 0 {
 		metrics.pagesWithComments++
 		metrics.totalCommentsFetched += crawledPage.CommentCount
+	}
+
+	if !rc.dryRun {
+		commentsMD := convert.CommentsToMarkdown(crawledPage.Comments)
+		if commentsMD != "" {
+			markdown = strings.TrimRight(markdown, "\n") + "\n\n" + commentsMD + "\n"
+		}
 	}
 
 	record := store.PageRecord{
@@ -285,9 +319,13 @@ func processRerenderedPage(ctx context.Context, rc *runContext, metrics *runMetr
 		record.ConfluenceParentID = crawledPage.ParentID
 	}
 
-	if err := rc.writer.AddPage(pageIDStr, record); err != nil {
-		logPageWithLevel("ERR", pageID, "write failed: %v", err)
-		return err
+	if rc.dryRun {
+		rc.writer.AddPageMetadata(pageIDStr, record)
+	} else {
+		if err := rc.writer.AddPage(pageIDStr, record); err != nil {
+			logPageWithLevel("ERR", pageID, "write failed: %v", err)
+			return err
+		}
 	}
 
 	storedRecord, ok := rc.writer.GetPages()[pageIDStr]
@@ -301,9 +339,56 @@ func processRerenderedPage(ctx context.Context, rc *runContext, metrics *runMetr
 	}
 	metrics.rerenderedCount++
 
-	logPageWithLevel("OK", pageID, "%s", crawledPage.Title)
+	if rc.dryRun {
+		logPageWithLevel("OK", pageID, "%s (dry-run)", crawledPage.Title)
+	} else {
+		logPageWithLevel("OK", pageID, "%s", crawledPage.Title)
+	}
 	metrics.successCount++
 	return nil
+}
+
+func reusedPageArtifactMissing(outputDir string, record store.PageRecord) bool {
+	localPath := strings.TrimSpace(record.LocalPath)
+	if localPath == "" {
+		return true
+	}
+
+	absPath := filepath.Join(outputDir, filepath.FromSlash(localPath))
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return true
+	}
+
+	return false
+}
+
+func previewPageAttachments(pageID string, attachments []confluenceclient.AttachmentData, maxSizeMB int) []store.AttachmentResult {
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	maxBytes := int64(maxSizeMB) * 1024 * 1024
+	results := make([]store.AttachmentResult, 0, len(attachments))
+	for _, a := range attachments {
+		result := store.AttachmentResult{OriginalName: a.Filename}
+		if maxBytes > 0 && a.FileSizeBytes > maxBytes {
+			result.Skipped = true
+			result.Error = fmt.Errorf("attachment %q skipped: size %d bytes exceeds limit of %d bytes", a.Filename, a.FileSizeBytes, maxBytes)
+			results = append(results, result)
+			continue
+		}
+		if strings.TrimSpace(a.ID) == "" {
+			result.Error = fmt.Errorf("attachment %q has no attachment ID", a.Filename)
+			results = append(results, result)
+			continue
+		}
+
+		result.Filename = store.PageAttachmentFilename(pageID, a.Filename)
+		result.FileID = a.FileID
+		results = append(results, result)
+	}
+
+	return results
 }
 
 func logPageWithLevel(level string, pageID int64, messageFormat string, args ...any) {
@@ -316,6 +401,19 @@ func logPageAttachmentWarning(pageID int64, err error) {
 }
 
 func finalizeRun(rc *runContext, metrics *runMetrics) (*runFinalizeResult, error) {
+	if rc.dryRun {
+		pagesPreview := snapshotPageRecords(rc.writer.GetPages())
+		pruneMetadataToCrawledSet(pagesPreview, rc.crawlResults)
+		rebuildIncomingLinks(pagesPreview)
+
+		reconcileStats := previewManagedArtifactReconcile(rc.previousPages, pagesPreview)
+		return &runFinalizeResult{
+			rewriteStats:       links.RewriteStats{},
+			reconcileStats:     reconcileStats,
+			checkpointAdvanced: false,
+		}, nil
+	}
+
 	pruneMetadataToCrawledSet(rc.writer.GetPages(), rc.crawlResults)
 
 	rewriteStats, err := finalizeTraversalOutput(rc.cfg.Output.Dir, rc.writer)
@@ -362,7 +460,12 @@ func finalizeRun(rc *runContext, metrics *runMetrics) (*runFinalizeResult, error
 func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFinalizeResult, elapsed time.Duration) {
 	stats := rc.crawler.Stats()
 	fmt.Printf("\n=== Crawl Complete ===\n")
-	fmt.Printf("Mode: %s\n", rc.mode)
+	if rc.dryRun {
+		fmt.Printf("Mode: %s (dry-run)\n", rc.mode)
+		fmt.Printf("Dry-run: no output artifacts, metadata, or checkpoints were written\n")
+	} else {
+		fmt.Printf("Mode: %s\n", rc.mode)
+	}
 	fmt.Printf("Total pages crawled: %d\n", stats["total_pages"])
 	if depthDist, ok := stats["depth_distribution"].(map[int]int); ok {
 		for depth := 0; depth <= rc.cfg.Crawl.MaxDepth; depth++ {
@@ -371,13 +474,21 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 			}
 		}
 	}
-	fmt.Printf("Pages written successfully: %d\n", metrics.successCount)
+	if rc.dryRun {
+		fmt.Printf("Pages processed successfully (predicted): %d\n", metrics.successCount)
+	} else {
+		fmt.Printf("Pages written successfully: %d\n", metrics.successCount)
+	}
 	fmt.Printf("Pages with errors: %d\n", metrics.errorCount)
 	fmt.Printf("Internal crawl links discovered (edge count): %d\n", stats["total_links"])
 	fmt.Printf("Unique internal target pages linked: %d\n", stats["unique_internal_targets"])
 	fmt.Printf("External links skipped (host filter): %d\n", stats["external_links_skipped"])
-	fmt.Printf("Pages with rewritten links: %d/%d\n", finalizeResult.rewriteStats.PagesUpdated, finalizeResult.rewriteStats.PagesProcessed)
-	fmt.Printf("Markdown links rewritten to local paths: %d/%d\n", finalizeResult.rewriteStats.LinksRewritten, finalizeResult.rewriteStats.LinksSeen)
+	if rc.dryRun {
+		fmt.Printf("Link rewrite pass: skipped (dry-run)\n")
+	} else {
+		fmt.Printf("Pages with rewritten links: %d/%d\n", finalizeResult.rewriteStats.PagesUpdated, finalizeResult.rewriteStats.PagesProcessed)
+		fmt.Printf("Markdown links rewritten to local paths: %d/%d\n", finalizeResult.rewriteStats.LinksRewritten, finalizeResult.rewriteStats.LinksSeen)
+	}
 	fmt.Printf("Pages with comments appended: %d\n", metrics.pagesWithComments)
 	fmt.Printf("Total comments fetched: %d\n", metrics.totalCommentsFetched)
 	fmt.Printf("Pages with comment fetch warnings: %d\n", metrics.commentFetchFailures)
@@ -394,16 +505,29 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 		fmt.Printf("Pages re-rendered: %d\n", metrics.rerenderedCount)
 		fmt.Printf("Pages reused without full re-processing: %d\n", metrics.reusedCount)
 		fmt.Printf("Re-render saves: %d (%.1f%%)\n", rerenderSavedCount, rerenderSavedPercent)
-		fmt.Printf("Managed files added/updated/deleted: %d/%d/%d\n", metrics.fileAddedCount, metrics.fileUpdatedCount, finalizeResult.reconcileStats.Deleted)
-		fmt.Printf("Attachments downloaded/reused: %d/%d\n", metrics.attachmentsDownloaded, metrics.attachmentsReused)
-		fmt.Printf("Output commit status: direct-write (non-transactional)\n")
-		if finalizeResult.checkpointAdvanced {
-			fmt.Printf("Checkpoint advanced: yes\n")
+		if rc.dryRun {
+			fmt.Printf("Managed files that would be added/updated/deleted: %d/%d/%d\n", metrics.fileAddedCount, metrics.fileUpdatedCount, finalizeResult.reconcileStats.Deleted)
 		} else {
-			fmt.Printf("Checkpoint advanced: no\n")
+			fmt.Printf("Managed files added/updated/deleted: %d/%d/%d\n", metrics.fileAddedCount, metrics.fileUpdatedCount, finalizeResult.reconcileStats.Deleted)
+		}
+		fmt.Printf("Attachments downloaded/reused: %d/%d\n", metrics.attachmentsDownloaded, metrics.attachmentsReused)
+		if rc.dryRun {
+			fmt.Printf("Output commit status: dry-run (no writes)\n")
+			fmt.Printf("Checkpoint advanced: no (dry-run suppresses checkpoint writes)\n")
+		} else {
+			fmt.Printf("Output commit status: direct-write (non-transactional)\n")
+			if finalizeResult.checkpointAdvanced {
+				fmt.Printf("Checkpoint advanced: yes\n")
+			} else {
+				fmt.Printf("Checkpoint advanced: no\n")
+			}
 		}
 	}
-	fmt.Printf("Managed artifacts deleted as stale: %d\n", finalizeResult.reconcileStats.Deleted)
+	if rc.dryRun {
+		fmt.Printf("Managed artifacts that would be deleted as stale: %d\n", finalizeResult.reconcileStats.Deleted)
+	} else {
+		fmt.Printf("Managed artifacts deleted as stale: %d\n", finalizeResult.reconcileStats.Deleted)
+	}
 	fmt.Printf("Output directory: %s\n", rc.cfg.Output.Dir)
 	fmt.Printf("Total time: %s\n", elapsed.Round(time.Second))
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,8 +7,29 @@ This guide covers practical runtime behavior, failure modes, and recovery steps.
 - Full mode crawls from configured seeds up to max depth.
 - Full mode clears the configured output directory before writing new crawl output.
 - Updates mode (v1.0 scope) uses the same seed-based traversal as full mode, then selectively re-processes dirty pages and reuses clean-page artifacts.
+- Dry-run mode (`--dry-run`) preserves traversal and decision logic but suppresses write side effects.
 - Output commit behavior is currently direct-write (non-transactional): files are written directly under the configured output directory during the run.
 - Page export is resilient: non-critical failures (for example comment fetch or attachment retrieval failures) should not block page Markdown output.
+
+### Dry-run behavior
+
+Dry-run is a modifier on `full` and `updates` modes.
+
+- Keeps traversal, link discovery, and updates dirty/clean decisions active.
+- Reuses the same scope-discovery inputs: ADF links, comment-body links, children expansion, and contentbylabel CQL expansion.
+- Skips markdown artifact generation/writes and all other output mutations.
+
+Suppressed side effects in dry-run:
+
+- no output directory clear
+- no page markdown writes
+- no attachment file writes
+- no metadata.json write
+- no index.md write
+- no stale artifact deletions
+- no checkpoint updates
+
+Summary output in dry-run presents predicted outcomes (for example would-be added/updated/deleted managed files).
 
 ## Common failure scenarios
 
@@ -204,8 +225,20 @@ Full crawl:
 confluence2md --mode full
 ```
 
+Full dry-run preview:
+
+```sh
+confluence2md --mode full --dry-run
+```
+
 Incremental refresh:
 
 ```sh
 confluence2md --mode updates
+```
+
+Updates dry-run preview:
+
+```sh
+confluence2md --mode updates --dry-run
 ```

--- a/internal/crawl/full.go
+++ b/internal/crawl/full.go
@@ -78,6 +78,7 @@ type CrawlNodeHandler func(ctx context.Context, pageID int64, depth int) *NodeHa
 type CrawlSession struct {
 	client        *confluence.Client
 	config        *config.Config
+	dryRun        bool
 	maxDepth      int
 	concurrency   int
 	seedSpaceKey  string // resolved alpha space key for title lookups
@@ -135,6 +136,11 @@ func (cs *CrawlSession) SetNodeHandler(handler CrawlNodeHandler) error {
 	}
 	cs.nodeHandler = handler
 	return nil
+}
+
+// SetDryRun enables or disables dry-run traversal behavior.
+func (cs *CrawlSession) SetDryRun(dryRun bool) {
+	cs.dryRun = dryRun
 }
 
 // EnableUpdatesMode switches traversal to updates-mode node handling.
@@ -302,20 +308,6 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 		}
 	}
 
-	// Convert to Markdown
-	markdown, err := convert.ToMarkdown(fetchedPage.Body.ADF.Value)
-	if err != nil {
-		page.FetchError = fmt.Sprintf("convert failed: %v", err)
-		return &NodeHandlerResult{Page: page, FetchError: page.FetchError, Title: page.Title}
-	}
-
-	// Prepend page title as H1 only when it is not already present.
-	if !hasLeadingTitleH1(markdown, page.Title) {
-		markdown = fmt.Sprintf("# %s\n\n%s", page.Title, markdown)
-	}
-
-	page.Markdown = markdown
-
 	// Fetch page comments (best-effort). Failure is non-fatal for page export.
 	comments, err := cs.client.GetPageComments(ctx, pageID)
 	if err != nil {
@@ -360,10 +352,11 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 	}
 
 	// If the page contains a "contentbylabel" macro, the listed pages are not
-	// represented as inline links in ADF — execute the embedded CQL query,
-	// add matching page IDs to the outgoing link set, and append a "Related
-	// pages" section to the rendered markdown so the link rewriter can later
-	// convert these Confluence URLs into local relative paths.
+	// represented as inline links in ADF — execute the embedded CQL query and
+	// add matching page IDs to the outgoing link set.
+	//
+	// In non-dry-run mode we also append a "Related pages" section to rendered
+	// markdown so link rewriting can convert these URLs to local relative paths.
 	for _, cql := range links.ExtractContentByLabelCQLs(fetchedPage.Body.ADF.Value) {
 		cqlIDs, err := cs.client.SearchPagesByCQL(ctx, cql)
 		if err != nil {
@@ -372,6 +365,10 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 			continue
 		}
 		page.OutgoingLinks = links.DedupPageIDs(append(page.OutgoingLinks, cqlIDs...))
+
+		if cs.dryRun {
+			continue
+		}
 
 		// Build a Related pages list and append to markdown. Use viewpage.action
 		// URLs — the same format the link rewriter resolves to local paths.
@@ -386,6 +383,22 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 				title, cs.config.BaseURL(), id)
 		}
 		page.Markdown += relatedBuf.String()
+	}
+
+	if !cs.dryRun {
+		// Convert to Markdown only when a real run needs rendered output.
+		markdown, err := convert.ToMarkdown(fetchedPage.Body.ADF.Value)
+		if err != nil {
+			page.FetchError = fmt.Sprintf("convert failed: %v", err)
+			return &NodeHandlerResult{Page: page, FetchError: page.FetchError, Title: page.Title}
+		}
+
+		// Prepend page title as H1 only when it is not already present.
+		if !hasLeadingTitleH1(markdown, page.Title) {
+			markdown = fmt.Sprintf("# %s\n\n%s", page.Title, markdown)
+		}
+
+		page.Markdown = markdown + page.Markdown
 	}
 
 	return &NodeHandlerResult{

--- a/internal/crawl/full_test.go
+++ b/internal/crawl/full_test.go
@@ -20,6 +20,25 @@ func TestSetNodeHandlerRejectsNil(t *testing.T) {
 	}
 }
 
+func TestSetDryRun(t *testing.T) {
+	cfg := &config.Config{Crawl: config.CrawlConfig{MaxDepth: 1, Concurrency: 1, RateLimitRPM: 60000, QueueSize: 10000}}
+	cs := NewCrawlSession(nil, cfg, "")
+
+	if cs.dryRun {
+		t.Fatalf("expected dryRun to default to false")
+	}
+
+	cs.SetDryRun(true)
+	if !cs.dryRun {
+		t.Fatalf("expected dryRun to be true after SetDryRun(true)")
+	}
+
+	cs.SetDryRun(false)
+	if cs.dryRun {
+		t.Fatalf("expected dryRun to be false after SetDryRun(false)")
+	}
+}
+
 func TestRunUsesSharedTraversalWithCustomNodeHandler(t *testing.T) {
 	cfg := &config.Config{
 		Crawl: config.CrawlConfig{


### PR DESCRIPTION
## Summary

Adds `--dry-run` for `--mode full` and `--mode updates` to preview crawl/update results without mutating output.

Keeps traversal + updates decision parity
Suppresses all write side effects (pages, attachments, metadata/index, deletes, checkpoints)
Marks dry-run output as predicted/no-write
Adds tests and docs
Resolves #43