### PR TITLE
fix(crawler): handle deleted pages in updates mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ What you get:
   - **updates**: run the same seed-based traversal as full mode, but selectively re-process dirty pages while reusing clean-page artifacts.
 - Supports a **dry-run** modifier (`--dry-run`) for both modes to preview traversal and updates decisions without writing output artifacts.
 
+In updates mode, pages that Confluence reports as trashed or no longer found are
+treated as deleted rather than failed fetches. Their metadata and managed local
+artifacts are removed, and references to their page IDs are pruned from the
+stored crawl graph. A detected deletion does not count as a page error or block
+successful checkpoint advancement.
+
 ## Download
 
 Pre-built binaries are available on the [Releases](https://github.com/gkoos/confluence2md/releases) page.
@@ -211,6 +217,7 @@ Output directory: ./output
 For updates mode, the summary additionally reports:
 
 - Reachable pages
+- Pages detected as deleted
 - Pages re-rendered
 - Pages reused without full re-processing
 - Re-render saves (count and percent)

--- a/cmd/crawler/finalize.go
+++ b/cmd/crawler/finalize.go
@@ -134,7 +134,10 @@ func pruneMetadataToCrawledSet(pages map[string]store.PageRecord, crawlResults m
 		return
 	}
 	reachable := make(map[string]struct{}, len(crawlResults))
-	for pageID := range crawlResults {
+	for pageID, crawledPage := range crawlResults {
+		if crawledPage == nil || crawledPage.Deleted {
+			continue
+		}
 		reachable[strconv.FormatInt(pageID, 10)] = struct{}{}
 	}
 	for pageID := range pages {

--- a/cmd/crawler/main_test.go
+++ b/cmd/crawler/main_test.go
@@ -364,6 +364,122 @@ func TestFinalizeRun_ZeroErrorsAdvanceCompletedAndSuccessful(t *testing.T) {
 	}
 }
 
+func TestDeletedPageIsRemovedFromMetadataAndManagedArtifacts(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	if err := w.AddPage("42", store.PageRecord{
+		ID:            "42",
+		Title:         "Deleted page",
+		StorageFormat: "# Deleted page\n",
+		Attachments:   []string{"42-diagram.png"},
+	}); err != nil {
+		t.Fatalf("AddPage returned error: %v", err)
+	}
+	previousPages := snapshotPageRecords(w.GetPages())
+	deletedPath := previousPages["42"].LocalPath
+	attachmentDir := filepath.Join(outDir, "attachments")
+	if err := os.MkdirAll(attachmentDir, 0755); err != nil {
+		t.Fatalf("create attachment directory: %v", err)
+	}
+	attachmentPath := filepath.Join(attachmentDir, "42-diagram.png")
+	if err := os.WriteFile(attachmentPath, []byte("image"), 0644); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	rc := &runContext{
+		mode:          "updates",
+		cfg:           &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:        w,
+		crawlResults:  map[int64]*crawl.CrawledPage{42: {ID: 42, Title: "Deleted page", Deleted: true}},
+		previousPages: previousPages,
+	}
+	metrics := &runMetrics{}
+
+	if err := processTraversalResults(context.Background(), rc, metrics); err != nil {
+		t.Fatalf("processTraversalResults returned error: %v", err)
+	}
+	result, err := finalizeRun(rc, metrics)
+	if err != nil {
+		t.Fatalf("finalizeRun returned error: %v", err)
+	}
+
+	if _, ok := w.GetPages()["42"]; ok {
+		t.Fatal("expected deleted page to be removed from metadata")
+	}
+	if _, statErr := os.Stat(filepath.Join(outDir, deletedPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected deleted page artifact to be removed, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(attachmentPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected deleted page attachment to be removed, stat err=%v", statErr)
+	}
+	if result.reconcileStats.Deleted != 2 {
+		t.Fatalf("expected two managed artifact deletions, got %d", result.reconcileStats.Deleted)
+	}
+	if !result.checkpointAdvanced {
+		t.Fatal("expected deletion-only run to advance the successful checkpoint")
+	}
+	if metrics.deletedCount != 1 {
+		t.Fatalf("expected one page detected as deleted, got %d", metrics.deletedCount)
+	}
+	if metrics.errorCount != 0 || metrics.successCount != 0 {
+		t.Fatalf("expected deletion not to count as success or error, got success=%d errors=%d", metrics.successCount, metrics.errorCount)
+	}
+}
+
+func TestDeletedPageDryRunPreviewsRemovalWithoutMutation(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	if err := w.AddPage("42", store.PageRecord{
+		ID:            "42",
+		Title:         "Deleted page",
+		StorageFormat: "# Deleted page\n",
+	}); err != nil {
+		t.Fatalf("AddPage returned error: %v", err)
+	}
+	previousPages := snapshotPageRecords(w.GetPages())
+	deletedPath := previousPages["42"].LocalPath
+
+	rc := &runContext{
+		mode:          "updates",
+		dryRun:        true,
+		cfg:           &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:        w,
+		crawlResults:  map[int64]*crawl.CrawledPage{42: {ID: 42, Title: "Deleted page", Deleted: true}},
+		previousPages: previousPages,
+	}
+	metrics := &runMetrics{}
+
+	if err := processTraversalResults(context.Background(), rc, metrics); err != nil {
+		t.Fatalf("processTraversalResults returned error: %v", err)
+	}
+	result, err := finalizeRun(rc, metrics)
+	if err != nil {
+		t.Fatalf("finalizeRun returned error: %v", err)
+	}
+
+	if result.reconcileStats.Deleted != 1 {
+		t.Fatalf("expected one previewed artifact deletion, got %d", result.reconcileStats.Deleted)
+	}
+	if metrics.deletedCount != 1 {
+		t.Fatalf("expected one page detected as deleted, got %d", metrics.deletedCount)
+	}
+	if result.checkpointAdvanced {
+		t.Fatal("expected dry-run not to advance the successful checkpoint")
+	}
+	if _, ok := w.GetPages()["42"]; !ok {
+		t.Fatal("expected dry-run to leave writer metadata unchanged")
+	}
+	if _, statErr := os.Stat(filepath.Join(outDir, deletedPath)); statErr != nil {
+		t.Fatalf("expected dry-run to retain page artifact, stat err=%v", statErr)
+	}
+}
+
 func TestFinalizeRun_DryRunSkipsWritesAndCheckpoints(t *testing.T) {
 	outDir := t.TempDir()
 	w, err := store.NewWriter(outDir)
@@ -516,9 +632,9 @@ func TestProcessReusedPage_DryRunSkipsArtifactMaterialization(t *testing.T) {
 	}
 	metrics := &runMetrics{}
 	crawledPage := &crawl.CrawledPage{
-		ID:           123,
-		Title:        "Decision Records",
-		Depth:        1,
+		ID:            123,
+		Title:         "Decision Records",
+		Depth:         1,
 		OutgoingLinks: []int64{555},
 	}
 
@@ -537,6 +653,101 @@ func TestProcessReusedPage_DryRunSkipsArtifactMaterialization(t *testing.T) {
 	}
 	if got := metrics.successCount; got != 1 {
 		t.Fatalf("expected success count 1, got %d", got)
+	}
+}
+
+func TestPruneDeletedOutgoingLinksFiltersEverySurvivingPage(t *testing.T) {
+	crawlResults := map[int64]*crawl.CrawledPage{
+		1: {ID: 1, Reused: true, OutgoingLinks: []int64{2, 3, 2}},
+		2: {ID: 2, Deleted: true, OutgoingLinks: []int64{4}},
+		3: {ID: 3, OutgoingLinks: []int64{2, 4}},
+		4: {ID: 4},
+	}
+
+	deletedPageIDs := collectDeletedPageIDs(crawlResults)
+	if _, ok := deletedPageIDs[2]; !ok || len(deletedPageIDs) != 1 {
+		t.Fatalf("unexpected deleted page set: %#v", deletedPageIDs)
+	}
+
+	pruneDeletedOutgoingLinks(crawlResults, deletedPageIDs)
+
+	if got := crawlResults[1].OutgoingLinks; len(got) != 1 || got[0] != 3 {
+		t.Fatalf("unexpected reused-page outgoing links: %#v", got)
+	}
+	if got := crawlResults[3].OutgoingLinks; len(got) != 1 || got[0] != 4 {
+		t.Fatalf("unexpected rerendered-page outgoing links: %#v", got)
+	}
+	if got := crawlResults[2].OutgoingLinks; len(got) != 1 || got[0] != 4 {
+		t.Fatalf("expected deleted page payload to remain untouched, got %#v", got)
+	}
+}
+
+func TestProcessTraversalResultsPersistsPrunedOutgoingLinks(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	previous := store.PageRecord{ID: "1", Title: "Reused", LocalPath: "reused_1.md", OutgoingLinks: []string{"2"}}
+	rc := &runContext{
+		mode:          "updates",
+		dryRun:        true,
+		cfg:           &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:        w,
+		previousPages: map[string]store.PageRecord{"1": previous},
+		crawlResults: map[int64]*crawl.CrawledPage{
+			1: {ID: 1, Title: "Reused", Reused: true, OutgoingLinks: []int64{2}},
+			2: {ID: 2, Title: "Deleted", Deleted: true},
+			3: {ID: 3, Title: "Rerendered", OutgoingLinks: []int64{2}},
+		},
+		oldManagedArtifacts: managedArtifactSet(map[string]store.PageRecord{"1": previous}),
+	}
+	metrics := &runMetrics{}
+
+	if err := processTraversalResults(context.Background(), rc, metrics); err != nil {
+		t.Fatalf("processTraversalResults returned error: %v", err)
+	}
+	for _, pageID := range []string{"1", "3"} {
+		record, ok := w.GetPages()[pageID]
+		if !ok {
+			t.Fatalf("expected page %s metadata to be written", pageID)
+		}
+		if len(record.OutgoingLinks) != 0 {
+			t.Fatalf("expected page %s deleted links to be pruned, got %#v", pageID, record.OutgoingLinks)
+		}
+	}
+	if _, ok := w.GetPages()["2"]; ok {
+		t.Fatal("expected deleted page metadata not to be written")
+	}
+}
+
+func TestFetchErrorResultIncrementsErrorsAndBlocksCheckpoint(t *testing.T) {
+	outDir := t.TempDir()
+	w, err := store.NewWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewWriter returned error: %v", err)
+	}
+	rc := &runContext{
+		mode:          "updates",
+		cfg:           &config.Config{Output: config.OutputConfig{Dir: outDir}},
+		writer:        w,
+		crawlResults:  map[int64]*crawl.CrawledPage{42: {ID: 42, FetchError: "fetch failed"}},
+		previousPages: map[string]store.PageRecord{},
+	}
+	metrics := &runMetrics{}
+
+	if err := processTraversalResults(context.Background(), rc, metrics); err != nil {
+		t.Fatalf("processTraversalResults returned error: %v", err)
+	}
+	if metrics.errorCount != 1 {
+		t.Fatalf("expected one page error, got %d", metrics.errorCount)
+	}
+	result, err := finalizeRun(rc, metrics)
+	if err != nil {
+		t.Fatalf("finalizeRun returned error: %v", err)
+	}
+	if result.checkpointAdvanced {
+		t.Fatal("expected fetch error to block successful checkpoint advancement")
 	}
 }
 

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -40,6 +40,7 @@ type runMetrics struct {
 	commentFetchFailures  int
 	reusedCount           int
 	rerenderedCount       int
+	deletedCount          int
 	fileAddedCount        int
 	fileUpdatedCount      int
 	attachmentsDownloaded int
@@ -142,7 +143,15 @@ func executeTraversal(ctx context.Context, rc *runContext) error {
 }
 
 func processTraversalResults(ctx context.Context, rc *runContext, metrics *runMetrics) error {
+	deletedPageIDs := collectDeletedPageIDs(rc.crawlResults)
+	pruneDeletedOutgoingLinks(rc.crawlResults, deletedPageIDs)
+
 	for pageID, crawledPage := range rc.crawlResults {
+		if crawledPage.Deleted {
+			metrics.deletedCount++
+			logPageWithLevel("INFO", pageID, "%s (deleted)", crawledPage.Title)
+			continue
+		}
 		if rc.mode == "updates" && crawledPage.Reused {
 			if err := processReusedPage(rc, metrics, pageID, crawledPage); err != nil {
 				metrics.errorCount++
@@ -157,6 +166,34 @@ func processTraversalResults(ctx context.Context, rc *runContext, metrics *runMe
 	}
 
 	return nil
+}
+
+func collectDeletedPageIDs(crawlResults map[int64]*crawl.CrawledPage) map[int64]struct{} {
+	deletedPageIDs := make(map[int64]struct{})
+	for pageID, crawledPage := range crawlResults {
+		if crawledPage != nil && crawledPage.Deleted {
+			deletedPageIDs[pageID] = struct{}{}
+		}
+	}
+	return deletedPageIDs
+}
+
+func pruneDeletedOutgoingLinks(crawlResults map[int64]*crawl.CrawledPage, deletedPageIDs map[int64]struct{}) {
+	if len(deletedPageIDs) == 0 {
+		return
+	}
+	for _, crawledPage := range crawlResults {
+		if crawledPage == nil || crawledPage.Deleted || len(crawledPage.OutgoingLinks) == 0 {
+			continue
+		}
+		filtered := crawledPage.OutgoingLinks[:0]
+		for _, targetID := range crawledPage.OutgoingLinks {
+			if _, deleted := deletedPageIDs[targetID]; !deleted {
+				filtered = append(filtered, targetID)
+			}
+		}
+		crawledPage.OutgoingLinks = filtered
+	}
 }
 
 func processReusedPage(rc *runContext, metrics *runMetrics, pageID int64, crawledPage *crawl.CrawledPage) error {
@@ -493,7 +530,7 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 	fmt.Printf("Total comments fetched: %d\n", metrics.totalCommentsFetched)
 	fmt.Printf("Pages with comment fetch warnings: %d\n", metrics.commentFetchFailures)
 	if rc.mode == "updates" {
-		reachablePages := len(rc.crawlResults)
+		reachablePages := len(rc.crawlResults) - metrics.deletedCount
 		renderCandidates := metrics.rerenderedCount + metrics.reusedCount
 		rerenderSavedCount := metrics.reusedCount
 		rerenderSavedPercent := 0.0
@@ -502,6 +539,7 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 		}
 
 		fmt.Printf("Reachable pages: %d\n", reachablePages)
+		fmt.Printf("Pages detected as deleted: %d\n", metrics.deletedCount)
 		fmt.Printf("Pages re-rendered: %d\n", metrics.rerenderedCount)
 		fmt.Printf("Pages reused without full re-processing: %d\n", metrics.reusedCount)
 		fmt.Printf("Re-render saves: %d (%.1f%%)\n", rerenderSavedCount, rerenderSavedPercent)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,6 +7,7 @@ This guide covers practical runtime behavior, failure modes, and recovery steps.
 - Full mode crawls from configured seeds up to max depth.
 - Full mode clears the configured output directory before writing new crawl output.
 - Updates mode (v1.0 scope) uses the same seed-based traversal as full mode, then selectively re-processes dirty pages and reuses clean-page artifacts.
+- During updates traversal, a page returned with Confluence status `trashed` or an HTTP 404 is classified as deleted. Deletion is an expected state, not a page error.
 - Dry-run mode (`--dry-run`) preserves traversal and decision logic but suppresses write side effects.
 - Output commit behavior is currently direct-write (non-transactional): files are written directly under the configured output directory during the run.
 - Page export is resilient: non-critical failures (for example comment fetch or attachment retrieval failures) should not block page Markdown output.
@@ -30,6 +31,7 @@ Suppressed side effects in dry-run:
 - no checkpoint updates
 
 Summary output in dry-run presents predicted outcomes (for example would-be added/updated/deleted managed files).
+Deleted pages are still detected and counted during an updates dry-run, but their metadata and managed artifacts remain unchanged.
 
 ## Common failure scenarios
 
@@ -120,10 +122,21 @@ If links are not rewritten as expected:
 - If a reused page's local markdown file is missing on disk, the crawler now recreates that file from stored content before rewrite/finalization.
 - This prevents avoidable updates-run failures caused by missing local artifacts from partial/manual output cleanup.
 
+## Updates-mode deleted pages
+
+- Confluence Cloud commonly returns a trashed page with HTTP 200 and `status: trashed`; permanently removed or otherwise missing pages may return HTTP 404. Updates mode treats both responses as deletion signals.
+- Deleted pages remain traversal results long enough for finalization to identify them, but they do not enqueue child links or enter the surviving metadata set.
+- Deleted page IDs are pruned from every surviving page's stored `outgoing_links`, preventing clean pages from rediscovering the deleted target on later runs.
+- Finalization removes the deleted page's metadata record, Markdown file, and managed attachments through the normal stale-artifact reconciliation pass.
+- A deletion increments the deleted-page counter without incrementing success or error counters. A deletion-only run can therefore advance the successful checkpoint.
+- Dry-run performs the same classification and reports the files that would be removed without changing metadata, artifacts, or checkpoints.
+
 ## Updates summary semantics
 
 When running in updates mode, summary counters are interpreted as follows:
 
+- `Reachable pages`: non-deleted pages retained in the current crawl result.
+- `Pages detected as deleted`: pages classified from HTTP 404 or Confluence `status: trashed` responses.
 - `Pages re-rendered`: pages that were fully re-processed because lightweight state checks identified changes (or a conservative fallback marked them dirty).
 - `Pages reused without full re-processing`: pages treated as clean and carried forward via metadata-only upsert.
 - `Checkpoint advanced`: `yes` only when the last successful checkpoint tuple (started_at/completed_at/mode) changed relative to the pre-run checkpoint snapshot.
@@ -136,7 +149,7 @@ The crawler persists two checkpoint tuples in `metadata.json`:
 - `last_completed_*`: updated for every run that reaches finalize + metadata save.
 - `last_successful_*`: updated only when the run has zero page errors.
 
-Updates-mode dirty checks compare previous page metadata against current lightweight page state (version/title/attachment signature). Checkpoint tuples are persisted for reporting and operational auditing.
+Updates-mode classification first checks lightweight page status for deletion, then compares previous page metadata against current version, title, and attachment signature for dirty/clean decisions. Checkpoint tuples are persisted for reporting and operational auditing.
 
 ## Confluence Cloud API quotas and scaling
 

--- a/internal/confluence/client.go
+++ b/internal/confluence/client.go
@@ -3,6 +3,7 @@ package confluence
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,6 +15,28 @@ import (
 	atlassian "github.com/ctreminiom/go-atlassian/v2/confluence/v2"
 	"github.com/gkoos/confluence2md/internal/config"
 )
+
+// httpStatusError preserves an HTTP response status while retaining the
+// original API error in the unwrap chain.
+type httpStatusError struct {
+	statusCode int
+	err        error
+}
+
+func (e *httpStatusError) Error() string {
+	return e.err.Error()
+}
+
+func (e *httpStatusError) Unwrap() error {
+	return e.err
+}
+
+// IsNotFound reports whether err was caused by an HTTP 404 response.
+// It recognizes status errors through any number of wrapping layers.
+func IsNotFound(err error) bool {
+	var statusErr *httpStatusError
+	return errors.As(err, &statusErr) && statusErr.statusCode == http.StatusNotFound
+}
 
 // Client wraps the Confluence API client used by the crawler.
 type Client struct {
@@ -109,7 +132,7 @@ func (c *Client) GetPageByID(ctx context.Context, pageID int64, spaceKey string)
 	page, response, err := c.api.Page.Get(ctx, int(pageID), "atlas_doc_format", false, 0)
 	if err != nil {
 		if response != nil {
-			return nil, fmt.Errorf("failed to fetch page %d (status %d): %w", pageID, response.Code, err)
+			return nil, fmt.Errorf("failed to fetch page %d (status %d): %w", pageID, response.Code, &httpStatusError{statusCode: response.Code, err: err})
 		}
 		return nil, fmt.Errorf("failed to fetch page %d: %w", pageID, err)
 	}
@@ -150,14 +173,15 @@ func (c *Client) GetPageState(ctx context.Context, pageID int64, includeAttachme
 	page, response, err := c.api.Page.Get(ctx, int(pageID), "", false, 0)
 	if err != nil {
 		if response != nil {
-			return nil, fmt.Errorf("failed to fetch page state %d (status %d): %w", pageID, response.Code, err)
+			return nil, fmt.Errorf("failed to fetch page state %d (status %d): %w", pageID, response.Code, &httpStatusError{statusCode: response.Code, err: err})
 		}
 		return nil, fmt.Errorf("failed to fetch page state %d: %w", pageID, err)
 	}
 
 	state := &PageStateData{
-		ID:    pageID,
-		Title: strings.TrimSpace(page.Title),
+		ID:     pageID,
+		Title:  strings.TrimSpace(page.Title),
+		Status: strings.TrimSpace(page.Status),
 	}
 	if page.Version != nil {
 		state.Version = page.Version.Number
@@ -307,5 +331,3 @@ func (c *Client) GetPageChildIDs(ctx context.Context, pageID int64) ([]int64, er
 
 	return ids, nil
 }
-
-

--- a/internal/confluence/client_errors_test.go
+++ b/internal/confluence/client_errors_test.go
@@ -1,0 +1,47 @@
+package confluence
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestIsNotFound(t *testing.T) {
+	notFound := &httpStatusError{
+		statusCode: http.StatusNotFound,
+		err:        errors.New("page does not exist"),
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "direct 404", err: notFound, want: true},
+		{name: "wrapped 404", err: fmt.Errorf("fetch page: %w", notFound), want: true},
+		{name: "server error", err: &httpStatusError{statusCode: http.StatusInternalServerError, err: errors.New("server error")}},
+		{name: "untyped error containing status", err: errors.New("request failed with status 404")},
+		{name: "nil", err: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFound(tt.err); got != tt.want {
+				t.Fatalf("IsNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPStatusErrorPreservesCause(t *testing.T) {
+	cause := errors.New("api error")
+	err := fmt.Errorf("failed to fetch page (status 404): %w", &httpStatusError{
+		statusCode: http.StatusNotFound,
+		err:        cause,
+	})
+
+	if !errors.Is(err, cause) {
+		t.Fatal("expected the original API error to remain in the unwrap chain")
+	}
+}

--- a/internal/confluence/models.go
+++ b/internal/confluence/models.go
@@ -4,21 +4,21 @@ import "time"
 
 // PageData holds full page content including storage format body.
 type PageData struct {
-	ID              string
-	Title           string
-	Version         int
-	Seed            string
-	StorageFormat   string
+	ID            string
+	Title         string
+	Version       int
+	Seed          string
+	StorageFormat string
 }
 
 // FullPageData represents a page with all fields needed for crawling
 type FullPageData struct {
-	ID             int64
-	Title          string
-	CreatedAt      string // ISO 8601 timestamp when page was created
-	AuthorID       string // Account ID of page creator
-	ParentID       string // Parent page ID in Confluence hierarchy
-	Version        struct {
+	ID        int64
+	Title     string
+	CreatedAt string // ISO 8601 timestamp when page was created
+	AuthorID  string // Account ID of page creator
+	ParentID  string // Parent page ID in Confluence hierarchy
+	Version   struct {
 		Number    int
 		CreatedAt string // ISO 8601 timestamp of last modification
 		AuthorID  string // Account ID of last modifier
@@ -62,6 +62,7 @@ type CommentData struct {
 type PageStateData struct {
 	ID                  int64
 	Title               string
+	Status              string
 	Version             int
 	AttachmentSignature string
 }

--- a/internal/crawl/full.go
+++ b/internal/crawl/full.go
@@ -22,6 +22,7 @@ type CrawledPage struct {
 	Title                string
 	Markdown             string
 	Reused               bool
+	Deleted              bool
 	Comments             []confluence.CommentData
 	CommentCount         int
 	CommentFetchError    string
@@ -62,11 +63,12 @@ type queueDropSample struct {
 const maxQueueDropSamples = 20
 
 // NodeHandlerResult is the mode-specific output produced per traversed node.
-// The traversal engine only depends on OutgoingLinks and FetchError.
+// The traversal engine only depends on OutgoingLinks, FetchError, and Deleted.
 type NodeHandlerResult struct {
 	Page                 *CrawledPage
 	OutgoingLinks        []int64
 	FetchError           string
+	Deleted              bool
 	Title                string
 	ExternalLinksSkipped int
 }
@@ -229,6 +231,18 @@ func (cs *CrawlSession) worker(ctx context.Context, wg *sync.WaitGroup) {
 		if result == nil {
 			result = &NodeHandlerResult{FetchError: "node handler returned nil result"}
 		}
+		if result.Deleted {
+			if result.Page == nil {
+				result.Page = &CrawledPage{
+					ID:        item.pageID,
+					Deleted:   true,
+					CrawledAt: time.Now(),
+					Depth:     item.depth,
+				}
+			} else {
+				result.Page.Deleted = true
+			}
+		}
 
 		title := result.Title
 		if title == "" && result.Page != nil {
@@ -248,7 +262,7 @@ func (cs *CrawlSession) worker(ctx context.Context, wg *sync.WaitGroup) {
 		<-cs.semaphore
 
 		childCount := 0
-		if result.FetchError == "" && item.depth < cs.maxDepth {
+		if !result.Deleted && result.FetchError == "" && item.depth < cs.maxDepth {
 			cs.enqueueChildren(item.depth, result.OutgoingLinks)
 			childCount = len(result.OutgoingLinks)
 		}
@@ -256,6 +270,8 @@ func (cs *CrawlSession) worker(ctx context.Context, wg *sync.WaitGroup) {
 		depthPrefix := fmt.Sprintf("D%d", item.depth)
 		if result.FetchError != "" {
 			fmt.Printf("  [%s] ERR  %d — %s: %s\n", depthPrefix, item.pageID, title, result.FetchError)
+		} else if result.Deleted {
+			fmt.Printf("  [%s] DEL  %d — %s\n", depthPrefix, item.pageID, title)
 		} else {
 			fmt.Printf("  [%s] %3d/%-3d  %d — %s  (+%d links, ext-skip:%d, queue:%d)\n",
 				depthPrefix, cs.totalFetched, visited, item.pageID, title, childCount, result.ExternalLinksSkipped, len(cs.queue))
@@ -418,8 +434,41 @@ func (cs *CrawlSession) processUpdatesNode(ctx context.Context, pageID int64, de
 
 	state, err := cs.client.GetPageState(ctx, pageID, cs.config.Attachments.Download)
 	if err != nil {
+		if confluence.IsNotFound(err) {
+			deletedPage := &CrawledPage{
+				ID:        pageID,
+				Deleted:   true,
+				CrawledAt: time.Now(),
+				Depth:     depth,
+			}
+			if exists {
+				deletedPage.Title = previous.Title
+			}
+			return &NodeHandlerResult{
+				Page:    deletedPage,
+				Deleted: true,
+				Title:   deletedPage.Title,
+			}
+		}
 		// Conservative fallback: unknown state is treated as dirty.
 		return cs.processFullNode(ctx, pageID, depth)
+	}
+	if state != nil && strings.EqualFold(strings.TrimSpace(state.Status), "trashed") {
+		deletedPage := &CrawledPage{
+			ID:        pageID,
+			Title:     state.Title,
+			Deleted:   true,
+			CrawledAt: time.Now(),
+			Depth:     depth,
+		}
+		if deletedPage.Title == "" && exists {
+			deletedPage.Title = previous.Title
+		}
+		return &NodeHandlerResult{
+			Page:    deletedPage,
+			Deleted: true,
+			Title:   deletedPage.Title,
+		}
 	}
 	if state == nil || strings.TrimSpace(state.Title) == "" {
 		// Conservative fallback for incomplete lightweight state.

--- a/internal/crawl/full_test.go
+++ b/internal/crawl/full_test.go
@@ -2,12 +2,14 @@ package crawl
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/gkoos/confluence2md/internal/confluence"
 	"github.com/gkoos/confluence2md/internal/config"
+	"github.com/gkoos/confluence2md/internal/confluence"
 	"github.com/gkoos/confluence2md/internal/store"
 )
 
@@ -105,9 +107,9 @@ func TestTraversalUsesMinimalDepthAcrossBranches(t *testing.T) {
 
 	graph := map[int64][]int64{
 		1: {2, 3},
-		2: {4},    // shortest path to 4 => depth 2
+		2: {4}, // shortest path to 4 => depth 2
 		3: {5},
-		5: {4},    // longer path to 4 => depth 3
+		5: {4}, // longer path to 4 => depth 3
 		4: {},
 	}
 
@@ -130,6 +132,54 @@ func TestTraversalUsesMinimalDepthAcrossBranches(t *testing.T) {
 
 	if got := depthByNode[4]; got != 2 {
 		t.Fatalf("expected node 4 at minimal depth 2, got %d", got)
+	}
+}
+
+func TestRunStoresDeletedNodeWithoutEnqueuingChildren(t *testing.T) {
+	cfg := &config.Config{
+		Crawl: config.CrawlConfig{
+			MaxDepth:     2,
+			Concurrency:  1,
+			RateLimitRPM: 60000,
+			QueueSize:    100,
+		},
+	}
+	cs := NewCrawlSession(nil, cfg, "")
+
+	visited := make(map[int64]int)
+	err := cs.SetNodeHandler(func(ctx context.Context, pageID int64, depth int) *NodeHandlerResult {
+		visited[pageID]++
+		switch pageID {
+		case 1:
+			page := &CrawledPage{ID: pageID, Depth: depth}
+			return &NodeHandlerResult{Page: page, OutgoingLinks: []int64{2}}
+		case 2:
+			// Include an outgoing link deliberately: deletion must take precedence.
+			return &NodeHandlerResult{Deleted: true, OutgoingLinks: []int64{3}, Title: "Gone"}
+		default:
+			return &NodeHandlerResult{Page: &CrawledPage{ID: pageID, Depth: depth}}
+		}
+	})
+	if err != nil {
+		t.Fatalf("SetNodeHandler returned error: %v", err)
+	}
+
+	results, runErr := cs.Run(context.Background(), []int64{1})
+	if runErr != nil {
+		t.Fatalf("Run returned error: %v", runErr)
+	}
+	if visited[2] != 1 {
+		t.Fatalf("expected deleted node 2 to be visited once, got %d", visited[2])
+	}
+	if visited[3] != 0 {
+		t.Fatalf("expected child of deleted node not to be visited, got %d visits", visited[3])
+	}
+	deletedPage, ok := results[2]
+	if !ok || deletedPage == nil || !deletedPage.Deleted {
+		t.Fatalf("expected deleted node in crawl results, got %#v", deletedPage)
+	}
+	if deletedPage.ID != 2 || deletedPage.Depth != 1 {
+		t.Fatalf("unexpected synthesized deleted page: %#v", deletedPage)
 	}
 }
 
@@ -182,6 +232,136 @@ func TestParseOutgoingLinkIDs(t *testing.T) {
 	}
 	if ids[0] != 123 || ids[1] != 456 {
 		t.Fatalf("unexpected parsed IDs: %#v", ids)
+	}
+}
+
+func TestProcessUpdatesNodeTreatsNotFoundAsDeleted(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message":"page not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Confluence: config.ConfluenceConfig{Username: "user", Token: "token"},
+		Crawl: config.CrawlConfig{
+			Seeds:        []string{server.URL + "/wiki/spaces/SPACE/pages/42/Page"},
+			Concurrency:  1,
+			RateLimitRPM: 60000,
+			QueueSize:    100,
+		},
+		Retry: config.RetryConfig{MaxAttempts: 1, InitialBackoffMS: 1},
+	}
+	client, err := confluence.NewClient(cfg.BaseURL(), cfg.Confluence.Username, cfg.Confluence.Token, cfg.Retry, cfg.Crawl.RateLimitRPM, cfg.Crawl.Concurrency)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	cs := NewCrawlSession(client, cfg, "SPACE")
+	cs.EnableUpdatesMode(map[string]store.PageRecord{
+		"42": {ID: "42", Title: "Deleted page"},
+	})
+
+	result := cs.processUpdatesNode(context.Background(), 42, 3)
+	if result == nil || !result.Deleted {
+		t.Fatalf("expected deleted node result, got %#v", result)
+	}
+	if result.FetchError != "" {
+		t.Fatalf("expected deletion not to be a fetch error, got %q", result.FetchError)
+	}
+	if result.Page == nil || !result.Page.Deleted {
+		t.Fatalf("expected deleted page payload, got %#v", result.Page)
+	}
+	if result.Page.ID != 42 || result.Page.Depth != 3 || result.Page.Title != "Deleted page" {
+		t.Fatalf("unexpected deleted page payload: %#v", result.Page)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only the state request and no full-fetch fallback, got %d requests", requestCount)
+	}
+}
+
+func TestProcessUpdatesNodeTreatsTrashedStatusAsDeleted(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"42","status":"trashed","title":"Page To Be Deleted","version":{"number":1}}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Confluence: config.ConfluenceConfig{Username: "user", Token: "token"},
+		Crawl: config.CrawlConfig{
+			Seeds:        []string{server.URL + "/wiki/spaces/SPACE/pages/42/Page"},
+			Concurrency:  1,
+			RateLimitRPM: 60000,
+			QueueSize:    100,
+		},
+		Retry: config.RetryConfig{MaxAttempts: 1, InitialBackoffMS: 1},
+	}
+	client, err := confluence.NewClient(cfg.BaseURL(), cfg.Confluence.Username, cfg.Confluence.Token, cfg.Retry, cfg.Crawl.RateLimitRPM, cfg.Crawl.Concurrency)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	cs := NewCrawlSession(client, cfg, "SPACE")
+	cs.EnableUpdatesMode(map[string]store.PageRecord{
+		"42": {ID: "42", Title: "Page To Be Deleted"},
+	})
+
+	result := cs.processUpdatesNode(context.Background(), 42, 1)
+	if result == nil || !result.Deleted {
+		t.Fatalf("expected trashed page to produce a deleted result, got %#v", result)
+	}
+	if result.FetchError != "" {
+		t.Fatalf("expected trashed page not to be a fetch error, got %q", result.FetchError)
+	}
+	if result.Page == nil || !result.Page.Deleted || result.Page.Title != "Page To Be Deleted" {
+		t.Fatalf("unexpected deleted page payload: %#v", result.Page)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only the state request and no full-fetch fallback, got %d requests", requestCount)
+	}
+}
+
+func TestProcessUpdatesNodeFallsBackToFullFetchForTransientError(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message":"temporary failure"}`, http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Confluence: config.ConfluenceConfig{Username: "user", Token: "token"},
+		Crawl: config.CrawlConfig{
+			Seeds:        []string{server.URL + "/wiki/spaces/SPACE/pages/42/Page"},
+			Concurrency:  1,
+			RateLimitRPM: 60000,
+			QueueSize:    100,
+		},
+		Retry: config.RetryConfig{MaxAttempts: 1, InitialBackoffMS: 1},
+	}
+	client, err := confluence.NewClient(cfg.BaseURL(), cfg.Confluence.Username, cfg.Confluence.Token, cfg.Retry, cfg.Crawl.RateLimitRPM, cfg.Crawl.Concurrency)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	cs := NewCrawlSession(client, cfg, "SPACE")
+	cs.EnableUpdatesMode(map[string]store.PageRecord{
+		"42": {ID: "42", Title: "Existing page"},
+	})
+
+	result := cs.processUpdatesNode(context.Background(), 42, 1)
+	if result == nil || result.Deleted {
+		t.Fatalf("expected non-deleted fallback result, got %#v", result)
+	}
+	if result.FetchError == "" || result.Page == nil || result.Page.FetchError == "" {
+		t.Fatalf("expected the failed full-fetch fallback to be reported, got %#v", result)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected state request followed by full-fetch fallback, got %d requests", requestCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix updates mode repeatedly processing deleted Confluence pages as errors.

- Detect pages returned as HTTP 404 or with Confluence `status: trashed`
- Treat deletion as an expected traversal result rather than a fetch failure
- Stop traversal through deleted pages
- Remove deleted page metadata, Markdown files, and managed attachments
- Prune deleted IDs from surviving pages' outgoing links
- Report deleted pages separately without blocking checkpoint advancement
- Document deletion and dry-run behavior
- Add regression coverage for deletion, transient errors, cleanup, and idempotency

## Validation

- `go test ./...`
- `go vet ./...`
- Live Confluence Cloud test:
  - Full crawl captured a parent linking to a disposable page
  - After trashing the page, updates mode detected one deletion with zero errors
  - The page file and metadata were removed
  - The parent’s stored outgoing link was pruned
  - The successful checkpoint advanced
  - A second updates run did not revisit the deleted page

Fixes #44