### PR TITLE
refactor(convert): unify HTML cell renderer dispatch

### DIFF
--- a/internal/convert/adf_render_test.go
+++ b/internal/convert/adf_render_test.go
@@ -118,6 +118,9 @@ func TestADFRender_HTMLTable_Colspan(t *testing.T) {
 	if !strings.Contains(got, `colspan="2"`) {
 		t.Fatalf("expected colspan attribute, got:\n%s", got)
 	}
+	if !strings.Contains(got, "<p>merged</p>") {
+		t.Fatalf("expected paragraph HTML inside colspan cell, got:\n%s", got)
+	}
 }
 
 func TestADFRender_HTMLTable_TaskList(t *testing.T) {
@@ -177,6 +180,98 @@ func TestADFRender_HTMLTable_DecisionList(t *testing.T) {
 	}
 	if !strings.Contains(got, "[ ] ") {
 		t.Fatalf("expected unchecked item for UNDECIDED, got:\n%s", got)
+	}
+}
+
+func TestHTMLCellRendererDescriptors(t *testing.T) {
+	expected := map[string]bool{
+		"paragraph":    false,
+		"heading":      true,
+		"codeBlock":    true,
+		"bulletList":   true,
+		"orderedList":  true,
+		"taskList":     true,
+		"decisionList": true,
+	}
+
+	if len(htmlCellRenderers) != len(expected) {
+		t.Fatalf("expected %d HTML cell renderers, got %d", len(expected), len(htmlCellRenderers))
+	}
+	for nodeType, requiresHTML := range expected {
+		renderer, ok := htmlCellRenderers[nodeType]
+		if !ok {
+			t.Fatalf("missing HTML cell renderer for %q", nodeType)
+		}
+		if renderer.render == nil {
+			t.Fatalf("HTML cell renderer for %q is nil", nodeType)
+		}
+		if renderer.requiresHTML != requiresHTML {
+			t.Fatalf("renderer %q requiresHTML = %v, want %v", nodeType, renderer.requiresHTML, requiresHTML)
+		}
+	}
+}
+
+func TestADFRender_HTMLTable_ComplexCellRenderers(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "heading",
+			content:  `{"type":"heading","attrs":{"level":3},"content":[{"type":"text","text":"Section"}]}`,
+			expected: "<h3>Section</h3>",
+		},
+		{
+			name:     "code block",
+			content:  `{"type":"codeBlock","content":[{"type":"text","text":"value"}]}`,
+			expected: "<pre><code>value</code></pre>",
+		},
+		{
+			name:     "bullet list",
+			content:  `{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}`,
+			expected: "<ul><li><p>item</p></li></ul>",
+		},
+		{
+			name:     "ordered list",
+			content:  `{"type":"orderedList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}`,
+			expected: "<ol><li><p>item</p></li></ol>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToMarkdown(adf(
+				`{"type":"table","content":[{"type":"tableRow","content":[` +
+					`{"type":"tableCell","content":[` + tt.content + `]}` +
+					`]}]}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got, "<table>") {
+				t.Fatalf("expected HTML table, got:\n%s", got)
+			}
+			if !strings.Contains(got, tt.expected) {
+				t.Fatalf("expected %q, got:\n%s", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestRenderNodeHTML_UnknownWrapperFallsBackToChildren(t *testing.T) {
+	node := ADFNode{
+		Type: "unknownBlock",
+		Content: []ADFNode{{
+			Type:    "paragraph",
+			Content: []ADFNode{{Type: "text", Text: "fallback"}},
+		}},
+	}
+	var buf strings.Builder
+
+	renderNodeHTML(node, &RenderContext{}, &buf)
+
+	if !strings.Contains(buf.String(), "fallback") {
+		t.Fatalf("expected fallback traversal to preserve child content, got %q", buf.String())
 	}
 }
 

--- a/internal/convert/adf_table.go
+++ b/internal/convert/adf_table.go
@@ -7,6 +7,15 @@ import (
 
 func init() {
 	Registry["table"] = renderTable
+	htmlCellRenderers = map[string]htmlCellRenderer{
+		"paragraph":    {render: renderParagraphHTML, requiresHTML: false},
+		"heading":      {render: renderHeadingHTML, requiresHTML: true},
+		"codeBlock":    {render: renderCodeBlockHTML, requiresHTML: true},
+		"bulletList":   {render: renderListHTML, requiresHTML: true},
+		"orderedList":  {render: renderListHTML, requiresHTML: true},
+		"taskList":     {render: renderTaskListHTML, requiresHTML: true},
+		"decisionList": {render: renderDecisionListHTML, requiresHTML: true},
+	}
 }
 
 func renderTable(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
@@ -29,17 +38,14 @@ func tableHasSpans(node ADFNode) bool {
 	return false
 }
 
-// complexCellTypes are ADF node types that cannot be faithfully represented
-// inside a GFM pipe-table cell and require full HTML output.
-var complexCellTypes = map[string]bool{
-	"heading":      true,
-	"codeBlock":    true,
-	"bulletList":   true,
-	"orderedList":  true,
-	"taskList":     true,
-	"decisionList": true,
-	"table":        true, // nested table
+type htmlCellRenderer struct {
+	render       func(ADFNode, *RenderContext, *strings.Builder)
+	requiresHTML bool
 }
+
+// htmlCellRenderers is the single source of truth for block nodes supported
+// inside HTML table cells and whether they force a table off the GFM path.
+var htmlCellRenderers map[string]htmlCellRenderer
 
 func tableHasComplexCells(node ADFNode) bool {
 	for _, row := range node.Content {
@@ -52,7 +58,7 @@ func tableHasComplexCells(node ADFNode) bool {
 
 func cellHasComplexContent(node ADFNode) bool {
 	for _, child := range node.Content {
-		if complexCellTypes[child.Type] {
+		if renderer, ok := htmlCellRenderers[child.Type]; ok && renderer.requiresHTML {
 			return true
 		}
 		if cellHasComplexContent(child) {
@@ -155,62 +161,80 @@ func renderCellHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
 }
 
 func renderNodeHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
-	switch node.Type {
-	case "heading":
-		lvl := min(max(attrInt(node, "level", 1), 1), 6)
-		tag := "h" + itoa(lvl)
-		buf.WriteString("<" + tag + ">")
-		var inner strings.Builder
-		walkChildren(node, ctx, &inner)
-		buf.WriteString(strings.TrimSpace(inner.String()))
-		buf.WriteString("</" + tag + ">")
-	case "paragraph":
-		var inner strings.Builder
-		walkChildren(node, ctx, &inner)
-		text := strings.TrimSpace(inner.String())
-		if text != "" {
-			buf.WriteString("<p>" + text + "</p>")
-		}
-	case "bulletList", "orderedList":
-		tag := "ul"
-		if node.Type == "orderedList" {
-			tag = "ol"
-		}
-		buf.WriteString("<" + tag + ">")
-		for _, item := range node.Content {
-			buf.WriteString("<li>")
-			var inner strings.Builder
-			renderCellHTML(item, ctx, &inner)
-			buf.WriteString(strings.TrimSpace(inner.String()))
-			buf.WriteString("</li>")
-		}
-		buf.WriteString("</" + tag + ">")
-	case "codeBlock":
-		buf.WriteString("<pre><code>")
-		var inner strings.Builder
-		walkChildren(node, ctx, &inner)
-		buf.WriteString(strings.TrimSpace(inner.String()))
-		buf.WriteString("</code></pre>")
-	case "taskList", "decisionList":
-		buf.WriteString("<ul>")
-		for _, item := range node.Content {
-			state := attrString(item, "state", "")
-			checkbox := "[ ] "
-			if state == "DONE" || state == "DECIDED" {
-				checkbox = "[x] "
-			}
-			buf.WriteString("<li>" + checkbox)
-			var inner strings.Builder
-			renderCellHTML(item, ctx, &inner)
-			buf.WriteString(strings.TrimSpace(inner.String()))
-			buf.WriteString("</li>")
-		}
-		buf.WriteString("</ul>")
-	default:
-		// For inline nodes and anything else, fall back to the markdown registry
-		// (inline text, marks, etc. render fine as markdown inside HTML)
-		walkChildren(node, ctx, buf)
+	if renderer, ok := htmlCellRenderers[node.Type]; ok {
+		renderer.render(node, ctx, buf)
+		return
 	}
+	// For inline nodes and anything else, fall back to the markdown registry
+	// (inline text, marks, etc. render fine as markdown inside HTML).
+	walkChildren(node, ctx, buf)
+}
+
+func renderHeadingHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	lvl := min(max(attrInt(node, "level", 1), 1), 6)
+	tag := "h" + itoa(lvl)
+	buf.WriteString("<" + tag + ">")
+	var inner strings.Builder
+	walkChildren(node, ctx, &inner)
+	buf.WriteString(strings.TrimSpace(inner.String()))
+	buf.WriteString("</" + tag + ">")
+}
+
+func renderParagraphHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	var inner strings.Builder
+	walkChildren(node, ctx, &inner)
+	text := strings.TrimSpace(inner.String())
+	if text != "" {
+		buf.WriteString("<p>" + text + "</p>")
+	}
+}
+
+func renderListHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	tag := "ul"
+	if node.Type == "orderedList" {
+		tag = "ol"
+	}
+	buf.WriteString("<" + tag + ">")
+	for _, item := range node.Content {
+		buf.WriteString("<li>")
+		var inner strings.Builder
+		renderCellHTML(item, ctx, &inner)
+		buf.WriteString(strings.TrimSpace(inner.String()))
+		buf.WriteString("</li>")
+	}
+	buf.WriteString("</" + tag + ">")
+}
+
+func renderCodeBlockHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	buf.WriteString("<pre><code>")
+	var inner strings.Builder
+	walkChildren(node, ctx, &inner)
+	buf.WriteString(strings.TrimSpace(inner.String()))
+	buf.WriteString("</code></pre>")
+}
+
+func renderTaskListHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	renderChecklistHTML(node, ctx, buf, "DONE")
+}
+
+func renderDecisionListHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder) {
+	renderChecklistHTML(node, ctx, buf, "DECIDED")
+}
+
+func renderChecklistHTML(node ADFNode, ctx *RenderContext, buf *strings.Builder, checkedState string) {
+	buf.WriteString("<ul>")
+	for _, item := range node.Content {
+		checkbox := "[ ] "
+		if attrString(item, "state", "") == checkedState {
+			checkbox = "[x] "
+		}
+		buf.WriteString("<li>" + checkbox)
+		var inner strings.Builder
+		renderCellHTML(item, ctx, &inner)
+		buf.WriteString(strings.TrimSpace(inner.String()))
+		buf.WriteString("</li>")
+	}
+	buf.WriteString("</ul>")
 }
 
 func itoa(n int) string {


### PR DESCRIPTION
## Summary

Consolidate HTML table-cell classification and rendering into a single descriptor map.

- Replace `complexCellTypes` and the `renderNodeHTML` switch
- Associate each supported node with its HTML renderer and `requiresHTML` classification
- Preserve GFM output for ordinary paragraph-only tables
- Extract focused HTML renderers for headings, paragraphs, lists, task/decision lists, and code blocks
- Retain fallback traversal for unknown and inline content
- Add regression coverage for classification and renderer dispatch

## Validation

- `go test ./...`
- `go vet ./...`
- Full crawl against Confluence Cloud completed successfully
- Inspected generated Markdown and confirmed ordinary tables remain GFM rather than being converted to HTML

Closes #47