### PR TITLE
fix(crawler): skip trashed pages in full mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ What you get:
   - **updates**: run the same seed-based traversal as full mode, but selectively re-process dirty pages while reusing clean-page artifacts.
 - Supports a **dry-run** modifier (`--dry-run`) for both modes to preview traversal and updates decisions without writing output artifacts.
 
-In updates mode, pages that Confluence reports as trashed or no longer found are
+In both full and updates modes, pages that Confluence reports as trashed or no longer found are
 treated as deleted rather than failed fetches. Their metadata and managed local
 artifacts are removed, and references to their page IDs are pruned from the
 stored crawl graph. A detected deletion does not count as a page error or block
@@ -203,6 +203,7 @@ Mode: full
 Total pages crawled: 13
 Pages written successfully: 13
 Pages with errors: 0
+Pages detected as deleted: 0
 Internal crawl links discovered (edge count): 14
 Unique internal target pages linked: 12
 External links skipped (host filter): 5
@@ -214,10 +215,9 @@ Pages with comment fetch warnings: 0
 Output directory: ./output
 ```
 
-For updates mode, the summary additionally reports:
+All modes report pages detected as deleted. For updates mode, the summary additionally reports:
 
 - Reachable pages
-- Pages detected as deleted
 - Pages re-rendered
 - Pages reused without full re-processing
 - Re-render saves (count and percent)

--- a/cmd/crawler/main_test.go
+++ b/cmd/crawler/main_test.go
@@ -364,7 +364,7 @@ func TestFinalizeRun_ZeroErrorsAdvanceCompletedAndSuccessful(t *testing.T) {
 	}
 }
 
-func TestDeletedPageIsRemovedFromMetadataAndManagedArtifacts(t *testing.T) {
+func TestFullModeDeletedPageIsRemovedFromMetadataAndManagedArtifacts(t *testing.T) {
 	outDir := t.TempDir()
 	w, err := store.NewWriter(outDir)
 	if err != nil {
@@ -390,7 +390,7 @@ func TestDeletedPageIsRemovedFromMetadataAndManagedArtifacts(t *testing.T) {
 	}
 
 	rc := &runContext{
-		mode:          "updates",
+		mode:          "full",
 		cfg:           &config.Config{Output: config.OutputConfig{Dir: outDir}},
 		writer:        w,
 		crawlResults:  map[int64]*crawl.CrawledPage{42: {ID: 42, Title: "Deleted page", Deleted: true}},

--- a/cmd/crawler/run_pipeline.go
+++ b/cmd/crawler/run_pipeline.go
@@ -517,6 +517,7 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 		fmt.Printf("Pages written successfully: %d\n", metrics.successCount)
 	}
 	fmt.Printf("Pages with errors: %d\n", metrics.errorCount)
+	fmt.Printf("Pages detected as deleted: %d\n", metrics.deletedCount)
 	fmt.Printf("Internal crawl links discovered (edge count): %d\n", stats["total_links"])
 	fmt.Printf("Unique internal target pages linked: %d\n", stats["unique_internal_targets"])
 	fmt.Printf("External links skipped (host filter): %d\n", stats["external_links_skipped"])
@@ -539,7 +540,6 @@ func printRunSummary(rc *runContext, metrics *runMetrics, finalizeResult *runFin
 		}
 
 		fmt.Printf("Reachable pages: %d\n", reachablePages)
-		fmt.Printf("Pages detected as deleted: %d\n", metrics.deletedCount)
 		fmt.Printf("Pages re-rendered: %d\n", metrics.rerenderedCount)
 		fmt.Printf("Pages reused without full re-processing: %d\n", metrics.reusedCount)
 		fmt.Printf("Re-render saves: %d (%.1f%%)\n", rerenderSavedCount, rerenderSavedPercent)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,7 +7,7 @@ This guide covers practical runtime behavior, failure modes, and recovery steps.
 - Full mode crawls from configured seeds up to max depth.
 - Full mode clears the configured output directory before writing new crawl output.
 - Updates mode (v1.0 scope) uses the same seed-based traversal as full mode, then selectively re-processes dirty pages and reuses clean-page artifacts.
-- During updates traversal, a page returned with Confluence status `trashed` or an HTTP 404 is classified as deleted. Deletion is an expected state, not a page error.
+- During full or updates traversal, a page returned with Confluence status `trashed` or an HTTP 404 is classified as deleted. Deletion is an expected state, not a page error.
 - Dry-run mode (`--dry-run`) preserves traversal and decision logic but suppresses write side effects.
 - Output commit behavior is currently direct-write (non-transactional): files are written directly under the configured output directory during the run.
 - Page export is resilient: non-critical failures (for example comment fetch or attachment retrieval failures) should not block page Markdown output.
@@ -122,21 +122,23 @@ If links are not rewritten as expected:
 - If a reused page's local markdown file is missing on disk, the crawler now recreates that file from stored content before rewrite/finalization.
 - This prevents avoidable updates-run failures caused by missing local artifacts from partial/manual output cleanup.
 
-## Updates-mode deleted pages
+## Deleted pages
 
-- Confluence Cloud commonly returns a trashed page with HTTP 200 and `status: trashed`; permanently removed or otherwise missing pages may return HTTP 404. Updates mode treats both responses as deletion signals.
+- Confluence Cloud commonly returns a trashed page with HTTP 200 and `status: trashed`; permanently removed or otherwise missing pages may return HTTP 404. Both crawl modes treat these responses as deletion signals.
 - Deleted pages remain traversal results long enough for finalization to identify them, but they do not enqueue child links or enter the surviving metadata set.
 - Deleted page IDs are pruned from every surviving page's stored `outgoing_links`, preventing clean pages from rediscovering the deleted target on later runs.
 - Finalization removes the deleted page's metadata record, Markdown file, and managed attachments through the normal stale-artifact reconciliation pass.
 - A deletion increments the deleted-page counter without incrementing success or error counters. A deletion-only run can therefore advance the successful checkpoint.
 - Dry-run performs the same classification and reports the files that would be removed without changing metadata, artifacts, or checkpoints.
+- Full mode clears existing output before traversal, so its essential deletion behavior is to avoid writing the trashed page back. If an unchanged source page still links to the trashed target, each later full crawl may rediscover and classify it as deleted.
 
 ## Updates summary semantics
 
-When running in updates mode, summary counters are interpreted as follows:
+All modes report `Pages detected as deleted`, counting pages classified from HTTP 404 or Confluence `status: trashed` responses.
+
+When running in updates mode, the additional summary counters are interpreted as follows:
 
 - `Reachable pages`: non-deleted pages retained in the current crawl result.
-- `Pages detected as deleted`: pages classified from HTTP 404 or Confluence `status: trashed` responses.
 - `Pages re-rendered`: pages that were fully re-processed because lightweight state checks identified changes (or a conservative fallback marked them dirty).
 - `Pages reused without full re-processing`: pages treated as clean and carried forward via metadata-only upsert.
 - `Checkpoint advanced`: `yes` only when the last successful checkpoint tuple (started_at/completed_at/mode) changed relative to the pre-run checkpoint snapshot.

--- a/internal/confluence/client.go
+++ b/internal/confluence/client.go
@@ -140,6 +140,7 @@ func (c *Client) GetPageByID(ctx context.Context, pageID int64, spaceKey string)
 	data := &FullPageData{
 		ID:        pageID,
 		Title:     page.Title,
+		Status:    strings.TrimSpace(page.Status),
 		CreatedAt: page.CreatedAt,
 		AuthorID:  page.AuthorID,
 		ParentID:  page.ParentID,

--- a/internal/confluence/models.go
+++ b/internal/confluence/models.go
@@ -15,6 +15,7 @@ type PageData struct {
 type FullPageData struct {
 	ID        int64
 	Title     string
+	Status    string
 	CreatedAt string // ISO 8601 timestamp when page was created
 	AuthorID  string // Account ID of page creator
 	ParentID  string // Parent page ID in Confluence hierarchy

--- a/internal/crawl/full.go
+++ b/internal/crawl/full.go
@@ -292,8 +292,14 @@ func (cs *CrawlSession) processFullNode(ctx context.Context, pageID int64, depth
 	// Fetch page by ID
 	fetchedPage, err := cs.client.GetPageByID(ctx, pageID, cs.seedSpaceKey)
 	if err != nil {
+		if confluence.IsNotFound(err) {
+			return deletedNodeResult(pageID, depth, "")
+		}
 		page.FetchError = fmt.Sprintf("fetch failed: %v", err)
 		return &NodeHandlerResult{Page: page, FetchError: page.FetchError}
+	}
+	if strings.EqualFold(strings.TrimSpace(fetchedPage.Status), "trashed") {
+		return deletedNodeResult(pageID, depth, fetchedPage.Title)
 	}
 
 	page.Title = fetchedPage.Title
@@ -435,40 +441,21 @@ func (cs *CrawlSession) processUpdatesNode(ctx context.Context, pageID int64, de
 	state, err := cs.client.GetPageState(ctx, pageID, cs.config.Attachments.Download)
 	if err != nil {
 		if confluence.IsNotFound(err) {
-			deletedPage := &CrawledPage{
-				ID:        pageID,
-				Deleted:   true,
-				CrawledAt: time.Now(),
-				Depth:     depth,
-			}
+			title := ""
 			if exists {
-				deletedPage.Title = previous.Title
+				title = previous.Title
 			}
-			return &NodeHandlerResult{
-				Page:    deletedPage,
-				Deleted: true,
-				Title:   deletedPage.Title,
-			}
+			return deletedNodeResult(pageID, depth, title)
 		}
 		// Conservative fallback: unknown state is treated as dirty.
 		return cs.processFullNode(ctx, pageID, depth)
 	}
 	if state != nil && strings.EqualFold(strings.TrimSpace(state.Status), "trashed") {
-		deletedPage := &CrawledPage{
-			ID:        pageID,
-			Title:     state.Title,
-			Deleted:   true,
-			CrawledAt: time.Now(),
-			Depth:     depth,
+		title := state.Title
+		if title == "" && exists {
+			title = previous.Title
 		}
-		if deletedPage.Title == "" && exists {
-			deletedPage.Title = previous.Title
-		}
-		return &NodeHandlerResult{
-			Page:    deletedPage,
-			Deleted: true,
-			Title:   deletedPage.Title,
-		}
+		return deletedNodeResult(pageID, depth, title)
 	}
 	if state == nil || strings.TrimSpace(state.Title) == "" {
 		// Conservative fallback for incomplete lightweight state.
@@ -518,6 +505,21 @@ func (cs *CrawlSession) processUpdatesNode(ctx context.Context, pageID int64, de
 		OutgoingLinks:        outgoing,
 		Title:                cleanPage.Title,
 		ExternalLinksSkipped: 0,
+	}
+}
+
+func deletedNodeResult(pageID int64, depth int, title string) *NodeHandlerResult {
+	page := &CrawledPage{
+		ID:        pageID,
+		Title:     title,
+		Deleted:   true,
+		CrawledAt: time.Now(),
+		Depth:     depth,
+	}
+	return &NodeHandlerResult{
+		Page:    page,
+		Deleted: true,
+		Title:   title,
 	}
 }
 

--- a/internal/crawl/full_test.go
+++ b/internal/crawl/full_test.go
@@ -365,6 +365,118 @@ func TestProcessUpdatesNodeFallsBackToFullFetchForTransientError(t *testing.T) {
 	}
 }
 
+func TestProcessFullNodeTreatsTrashedStatusAsDeleted(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"42","status":"trashed","title":"Deleted page","version":{"number":1}}`))
+	}))
+	defer server.Close()
+
+	cs := newTestCrawlSession(t, server.URL)
+	result := cs.processFullNode(context.Background(), 42, 2)
+
+	assertDeletedNodeResult(t, result, 42, 2, "Deleted page")
+	if requestCount != 1 {
+		t.Fatalf("expected only the full page request, got %d requests", requestCount)
+	}
+}
+
+func TestProcessFullNodeTreatsNotFoundAsDeleted(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message":"page not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cs := newTestCrawlSession(t, server.URL)
+	result := cs.processFullNode(context.Background(), 42, 2)
+
+	assertDeletedNodeResult(t, result, 42, 2, "")
+	if requestCount != 1 {
+		t.Fatalf("expected only the full page request, got %d requests", requestCount)
+	}
+}
+
+func TestProcessFullNodeKeepsTransientFailureAsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"temporary failure"}`, http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cs := newTestCrawlSession(t, server.URL)
+	result := cs.processFullNode(context.Background(), 42, 2)
+
+	if result == nil || result.Deleted {
+		t.Fatalf("expected non-deleted error result, got %#v", result)
+	}
+	if result.FetchError == "" || result.Page == nil || result.Page.FetchError == "" {
+		t.Fatalf("expected transient failure to remain a fetch error, got %#v", result)
+	}
+}
+
+func TestProcessUpdatesNodeHandlesDeletionBetweenStateAndFullFetch(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			_, _ = w.Write([]byte(`{"id":"42","status":"current","title":"Page","version":{"number":2}}`))
+			return
+		}
+		http.Error(w, `{"message":"page not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cs := newTestCrawlSession(t, server.URL)
+	cs.EnableUpdatesMode(map[string]store.PageRecord{
+		"42": {ID: "42", Title: "Page", Version: 1},
+	})
+	result := cs.processUpdatesNode(context.Background(), 42, 1)
+
+	assertDeletedNodeResult(t, result, 42, 1, "")
+	if requestCount != 2 {
+		t.Fatalf("expected state request followed by full page request, got %d requests", requestCount)
+	}
+}
+
+func newTestCrawlSession(t *testing.T, serverURL string) *CrawlSession {
+	t.Helper()
+	cfg := &config.Config{
+		Confluence: config.ConfluenceConfig{Username: "user", Token: "token"},
+		Crawl: config.CrawlConfig{
+			Seeds:        []string{serverURL + "/wiki/spaces/SPACE/pages/42/Page"},
+			Concurrency:  1,
+			RateLimitRPM: 60000,
+			QueueSize:    100,
+		},
+		Retry: config.RetryConfig{MaxAttempts: 1, InitialBackoffMS: 1},
+	}
+	client, err := confluence.NewClient(cfg.BaseURL(), cfg.Confluence.Username, cfg.Confluence.Token, cfg.Retry, cfg.Crawl.RateLimitRPM, cfg.Crawl.Concurrency)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	return NewCrawlSession(client, cfg, "SPACE")
+}
+
+func assertDeletedNodeResult(t *testing.T, result *NodeHandlerResult, pageID int64, depth int, title string) {
+	t.Helper()
+	if result == nil || !result.Deleted || result.FetchError != "" {
+		t.Fatalf("expected deletion without fetch error, got %#v", result)
+	}
+	if result.Page == nil || !result.Page.Deleted {
+		t.Fatalf("expected deleted page payload, got %#v", result.Page)
+	}
+	if result.Page.ID != pageID || result.Page.Depth != depth || result.Page.Title != title {
+		t.Fatalf("unexpected deleted page payload: %#v", result.Page)
+	}
+	if result.Page.CrawledAt.IsZero() {
+		t.Fatal("expected deleted page crawl timestamp")
+	}
+}
+
 func TestRun_FailsLoudlyWhenQueueSaturates(t *testing.T) {
 	cfg := &config.Config{
 		Crawl: config.CrawlConfig{


### PR DESCRIPTION
## Summary

Prevent full crawls from exporting Confluence pages that have been moved to trash.

- Preserve page status in full-page API responses
- Treat HTTP 404 and `status: trashed` as deleted-page results
- Reuse the existing deletion pipeline across full and updates modes
- Avoid fetching comments, attachments, children, or rendering deleted pages
- Prune deleted IDs from surviving pages’ outgoing links
- Report detected deletions in full-mode summaries
- Cover deletion between the updates state check and full fetch
- Document deletion behavior across both crawl modes

## Validation

- `go test ./...`
- `go vet ./...`
- Live Confluence Cloud full crawl:
  - Trashed page was logged as deleted
  - Six surviving pages were written
  - Deleted page was absent from metadata and local files
  - Parent metadata no longer referenced the deleted page
  - Zero page errors
  - Successful full-mode checkpoint advanced

Fixes #64