### PR TITLE
ci(release): add check-latest to setup-go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
           cache: true
 
       - name: Run govulncheck


### PR DESCRIPTION
Matches ci.yml so govulncheck runs against the latest Go patch instead of a stale cached one.